### PR TITLE
Add validator for de-duplicating identical fields in a record

### DIFF
--- a/lib/validators/identical-field-eliminator.js
+++ b/lib/validators/identical-field-eliminator.js
@@ -1,0 +1,90 @@
+/**
+ *
+ * @licstart  The following is the entire license notice for the JavaScript code in this file.
+ *
+ * Melinda-related validators for @natlibfi/marc-record-validate
+ *
+ * Copyright (c) 2014-2017 University Of Helsinki (The National Library Of Finland)
+ *
+ * This file is part of marc-record-validators-melinda
+ *
+ * marc-record-validators-melinda is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @licend  The above is the entire license notice
+ * for the JavaScript code in this file.
+ *
+ **/
+
+/**
+ * This validator de-duplicates identical fields in a record.
+ */
+
+/* istanbul ignore next: umd wrapper */
+(function (root, factory) {
+
+  'use strict';
+
+  if (typeof define === 'function' && define.amd) {
+    define(['@natlibfi/es6-polyfills/lib/polyfills/promise', '@natlibfi/marc-record-validate/lib/utils'], factory);
+  } else if (typeof module === 'object' && module.exports) {
+    module.exports = factory(require('@natlibfi/es6-polyfills/lib/polyfills/promise'), require('@natlibfi/marc-record-validate/lib/utils'));
+  }
+
+}(this, factory));
+
+function factory(Promise, utils) {
+
+  'use strict';
+
+  function hasDuplicates(record, field) {
+     return record.fields
+      .filter(function(f) {
+        return JSON.stringify(field) === JSON.stringify(f);
+      })
+      .length > 1;
+  }
+
+  function getFields(record) {
+    return record.fields.filter(function(field) {
+      return hasDuplicates(record, field);
+    });
+  }
+
+  return {
+    name: 'identical-field-eliminator',
+    factory: function() {
+      return {
+        validate: function(record) {
+          return Promise.resolve(getFields(record).map(function(field) {
+            if (hasDuplicates(record, field)) {
+              /**
+               * Since each field that has a duplicate generates a warning,
+               * each pair of duplicate fields generates two identical
+               * warnings.
+               */
+              return utils.validate.warning('Field has an identical duplicate in record', field);
+            }
+          }));
+        },
+        fix: function(record) {
+          return Promise.resolve(record.fields.map(function(field) {
+            if (hasDuplicates(record, field)) {
+              return utils.fix.removeField(record, field);
+            }
+          }));
+        }
+      };
+    }
+  };
+}

--- a/test/validators/identical-field-eliminator.spec.js
+++ b/test/validators/identical-field-eliminator.spec.js
@@ -1,0 +1,167 @@
+/**
+ *
+ * @licstart  The following is the entire license notice for the JavaScript code in this file.
+ *
+ * Melinda-related validators for @natlibfi/marc-record-validate
+ *
+ * Copyright (c) 2014-2017 University Of Helsinki (The National Library Of Finland)
+ *
+ * This file is part of marc-record-validators-melinda
+ *
+ * marc-record-validators-melinda is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @licend  The above is the entire license notice
+ * for the JavaScript code in this file.
+ *
+ **/
+
+/* istanbul ignore next: umd wrapper */
+(function (root, factory) {
+
+  'use strict';
+
+  if (typeof define === 'function' && define.amd) {
+    define([
+      'chai/chai',
+      'chai-as-promised',
+      'marc-record-js',
+      '../../lib/validators/identical-field-eliminator'
+    ], factory);
+  } else if (typeof module === 'object' && module.exports) {
+    module.exports = factory(
+      require('chai'),
+      require('chai-as-promised'),
+      require('marc-record-js'),
+      require('../../lib/validators/identical-field-eliminator')
+    );
+  }
+
+}(this, factory));
+
+function factory(chai, chaiAsPromised, MarcRecord, validator_factory)
+{
+
+  'use strict';
+
+  var expect = chai.expect;
+
+  chai.use(chaiAsPromised);
+
+  describe('identical-field-eliminator', function() {
+
+    it('Should be the expected object', function() {
+      expect(validator_factory).to.be.an('object');
+      expect(validator_factory.name).to.be.a('string');
+      expect(validator_factory.factory).to.be.a('function');
+    });
+
+    describe('#factory', function() {
+
+      it('Should return the expected object', function() {
+        expect(validator_factory.factory('foo')).to.be.an('object').and.to
+          .respondTo('validate').and.to
+          .respondTo('fix');
+      });
+
+      describe('object', function() {
+
+        describe('#validate', function() {
+
+          it('Should resolve with an array', function() {
+            return expect(validator_factory.factory('foo').validate(new MarcRecord())).to.eventually.eql([]);
+          });
+
+          it('Should generate two warnings', function() {
+            return expect(validator_factory.factory('foo').validate(new MarcRecord({
+              fields: [
+                {
+                  tag: 'foo',
+                  ind1: ' ',
+                  value: 'bar'
+                },
+                {
+                  tag: 'foo',
+                  ind1: ' ',
+                  value: 'bar'
+                }
+              ]
+            }))).to.eventually.have.lengthOf(2);
+          });
+
+          it('Should not de-duplicate fields with different indicator 1', function() {
+            return expect(validator_factory.factory('foo').validate(new MarcRecord({
+              fields: [
+                {
+                  tag: 'foo',
+                  ind1: ' ',
+                  subfields: [{
+                    code: 'a',
+                    value: 'fubar'
+                  }]
+                },
+                {
+                  tag: 'foo',
+                  ind1: '1',
+                  subfields: [{
+                    code: 'a',
+                    value: 'fubar'
+                  }]
+                }
+              ]
+            }))).to.eventually.eql([]);
+          });
+
+        });
+
+        describe('#fix', function() {
+
+          it('Should resolve with an array', function() {
+            return expect(validator_factory.factory('foo').fix(new MarcRecord())).to.eventually.be.an('array');
+          });
+
+          it("Should fix the record", function() {
+
+            var record = new MarcRecord({
+              fields: [
+                {
+                  tag: 'foo',
+                  ind1: ' ',
+                  value: 'bar'
+                },
+                {
+                  tag: 'foo',
+                  ind1: ' ',
+                  value: 'bar'
+                }
+              ]
+            }),
+            record_original = record.toJsonObject();
+
+            return validator_factory.factory('foo').fix(record).then(function(results) {
+
+              expect(record_original).to.not.eql(record.toJsonObject());
+
+            });
+
+          });
+
+        });
+
+      });
+
+    });
+
+  });
+
+}


### PR DESCRIPTION
The new validator is functionally identical to [IdenticalFieldEliminator.js](https://github.com/NatLibFi/marc-record-validate-legacy-cli/blob/master/ui/validators/IdenticalFieldEliminator.js) that has been used a lot with the legacy-client. It is useful for pruning the duplicated CAT fields generated by the API, for example.