### PR TITLE
New functionality to #264

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -695,13 +695,13 @@
 		},
 		"babel-plugin-syntax-async-functions": {
 			"version": "6.13.0",
-			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
 			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
 			"dev": true
 		},
 		"babel-plugin-syntax-exponentiation-operator": {
 			"version": "6.13.0",
-			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
 			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
 			"dev": true
 		},
@@ -1442,7 +1442,7 @@
 		},
 		"chalk": {
 			"version": "1.1.3",
-			"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 			"dev": true,
 			"requires": {
@@ -1970,7 +1970,7 @@
 			"dependencies": {
 				"commander": {
 					"version": "2.9.0",
-					"resolved": "http://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
 					"integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
 					"dev": true,
 					"requires": {
@@ -3319,7 +3319,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -3734,7 +3735,8 @@
 				"safe-buffer": {
 					"version": "5.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -3790,6 +3792,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -3833,12 +3836,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -4054,7 +4059,7 @@
 		},
 		"got": {
 			"version": "6.7.1",
-			"resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+			"resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
 			"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
 			"dev": true,
 			"requires": {
@@ -4604,7 +4609,7 @@
 		},
 		"is-obj": {
 			"version": "1.0.1",
-			"resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
 			"dev": true
 		},
@@ -5400,7 +5405,7 @@
 		},
 		"minimist": {
 			"version": "0.0.8",
-			"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 			"dev": true
 		},
@@ -5427,7 +5432,7 @@
 		},
 		"mkdirp": {
 			"version": "0.5.1",
-			"resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 			"dev": true,
 			"requires": {
@@ -8380,7 +8385,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				}
@@ -8409,7 +8414,7 @@
 		},
 		"readable-stream": {
 			"version": "2.3.6",
-			"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"dev": true,
 			"requires": {
@@ -8878,7 +8883,7 @@
 		},
 		"request": {
 			"version": "2.79.0",
-			"resolved": "http://registry.npmjs.org/request/-/request-2.79.0.tgz",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
 			"integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
 			"dev": true,
 			"requires": {
@@ -9596,7 +9601,7 @@
 		},
 		"through": {
 			"version": "2.3.8",
-			"resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
 		},
 		"timed-out": {
@@ -10014,7 +10019,7 @@
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
-			"resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"dev": true,
 			"requires": {

--- a/src/ending-punctuation-conf.js
+++ b/src/ending-punctuation-conf.js
@@ -134,7 +134,7 @@ const confSpec = [
 		index: null,
 		punc: false,
 		special: null
-	}, { // 	250	KYLLÄ
+	}, { // 250	KYLLÄ
 		rangeStart: null,
 		rangeEnd: null,
 		index: 250,
@@ -167,8 +167,11 @@ const confSpec = [
 		index: 264,
 		punc: true,
 		special: {
-			ifLast: 'c',
-			ind: '4'
+			ifBoth: true,
+			puncSubField: 'c',
+			ifInd2: ['0', '1', '2', '3'],
+			ifLastCharNot: ']-)?',
+			noPuncIfInd2: ['4']
 		}
 	}, { //	270	EI
 		rangeStart: null,


### PR DESCRIPTION
Now uses new rules that have both to be matched. (ind2 = 0,1,2 or 3 and last char not special char) Removed old functionality that checked punctuation from second last field if record has copyright mark. (now indicated with ind2 = 4)