### PR TITLE
Urn validator added

### DIFF
--- a/src/access-rights.js
+++ b/src/access-rights.js
@@ -30,47 +30,47 @@
 
 'use strict';
 
-import fetch from 'node-fetch';
-
-const URN_GENERATOR_URL = 'http://generator.urn.fi/cgi-bin/urn_generator.cgi?type=nbn';
-
 export default async function () {
 	async function fix(record) {
-		let URN = '';
-		const isbn = record.fields.reduce((acc, f) => {
-			if (f.tag === '020') {
-				const a = f.subfields.find(sf => sf.code === 'a');
-				acc = a ? a.value : undefined;
-				return acc;
-			}
-
-			return acc;
-		}, undefined);
-
-		if (isbn) {
-			URN = 'http://urn.fi/URN:ISBN:' + isbn;
-		} else {
-			const response = await fetch(URN_GENERATOR_URL);
-			const body = await response.text();
-			URN = 'http://urn.fi/' + body;
-		}
-
 		record.insertField({
-			tag: '856',
-			ind1: '4',
-			ind2: '0',
+			tag: '506',
+			ind1: '1',
 			subfields: [
-				{code: 'u', value: URN}
+				{code: 'a', value: 'Aineisto on käytettävissä vapaakappalekirjastoissa.'},
+				{code: 'f', value: 'Online access with authorization.'},
+				{code: '2', value: 'star'},
+				{code: '5', value: 'FI-Vapaa'},
+				{code: '9', value: 'FENNI<KEEP>'}
 			]
 		});
+
+		record.insertField({
+			tag: '540',
+			subfields: [
+				{code: 'a', value: 'Aineisto on käytettävissä tutkimus- ja muihin tarkoituksiin;'},
+				{code: 'b', value: 'Kansalliskirjasto;'},
+				{code: 'c', value: 'Laki kulttuuriaineistojen tallettamisesta ja säilyttämisestä'},
+				{code: 'u', value: 'http://www.finlex.fi/fi/laki/ajantasa/2007/20071433'},
+				{code: '5', value: 'FI-Vapaa'},
+				{code: '9', value: 'FENNI<KEEP>'}
+			]
+		});
+
+		const f856 = record.get(/^856$/).shift();
+		if (f856) {
+			f856.subfields.push(
+				{code: 'z', value: 'Käytettävissä vapaakappalekirjastoissa'},
+				{code: '5', value: 'FI-Vapaa'}
+			);
+		}
 
 		return true;
 	}
 
 	return {
-		description: 'Adds URN for record, to 856-field (if not existing)',
+		description: 'Adds access rights fields for a record (if not existing)',
 		validate: async record => ({
-			valid: record.fields.some(sf => sf.tag === '856')
+			valid: record.fields.some(sf => sf.tag === '506')
 		}),
 		fix
 	};

--- a/src/access-rights.spec.js
+++ b/src/access-rights.spec.js
@@ -1,0 +1,195 @@
+/**
+ *
+ * @licstart  The following is the entire license notice for the JavaScript code in this file.
+ *
+ * MARC record validators used in Melinda
+ *
+ * Copyright (c) 2014-2019 University Of Helsinki (The National Library Of Finland)
+ *
+ * This file is part of marc-record-validators-melinda
+ *
+ * marc-record-validators-melinda program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * marc-record-validators-melinda is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @licend  The above is the entire license notice
+ * for the JavaScript code in this file.
+ *
+ */
+
+/* eslint-disable no-undef, max-nested-callbacks, no-unused-expressions */
+
+'use strict';
+
+import {expect} from 'chai';
+import {MarcRecord} from '@natlibfi/marc-record';
+import validatorFactory from '../src/access-rights';
+
+describe('access-rights', () => {
+	it('Creates a validator', async () => {
+		const validator = await validatorFactory();
+
+		expect(validator)
+			.to.be.an('object')
+			.that.has.any.keys('description', 'validate');
+
+		expect(validator.description).to.be.a('string');
+		expect(validator.validate).to.be.a('function');
+	});
+
+	describe('#validate', () => {
+		it('Finds the record valid', async () => {
+			const validator = await validatorFactory();
+			const record = new MarcRecord({
+				fields: [
+					{
+						tag: '506',
+						ind1: '1',
+						subfields: [
+							{code: 'a', value: 'Aineisto on käytettävissä vapaakappalekirjastoissa.'},
+							{code: 'f', value: 'Online access with authorization.'},
+							{code: '2', value: 'star'},
+							{code: '5', value: 'FI-Vapaa'},
+							{code: '9', value: 'FENNI<KEEP>'}
+						]
+					}
+				]
+			});
+			const result = await validator.validate(record);
+
+			expect(result).to.eql({valid: true});
+		});
+
+		it('Finds the record invalid', async () => {
+			const validator = await validatorFactory();
+			const record = new MarcRecord({
+				fields: [
+					{
+						tag: '020',
+						ind1: ' ',
+						ind2: ' ',
+						subfields: [{code: 'a', value: '978-951-9155-47-0'}]
+					}
+				]
+			});
+			const result = await validator.validate(record);
+
+			expect(result).to.eql({valid: false});
+		});
+	});
+
+	describe('#fix', () => {
+		it('Creates access rights fields', async () => {
+			const validator = await validatorFactory();
+			const record = new MarcRecord({
+				fields: [
+					{
+						tag: '020',
+						ind1: ' ',
+						ind2: ' ',
+						subfields: [{code: 'a', value: '978-951-9155-47-0'}]
+					}
+				]
+			});
+
+			await validator.fix(record);
+
+			expect(record.fields).to.eql([
+				{tag: '020',	ind1: ' ', ind2: ' ', subfields: [
+					{code: 'a', value: '978-951-9155-47-0'}
+				]
+				},
+				{
+					tag: '506',
+					ind1: '1',
+					ind2: ' ',
+					subfields: [
+						{code: 'a', value: 'Aineisto on käytettävissä vapaakappalekirjastoissa.'},
+						{code: 'f', value: 'Online access with authorization.'},
+						{code: '2', value: 'star'},
+						{code: '5', value: 'FI-Vapaa'},
+						{code: '9', value: 'FENNI<KEEP>'}
+					]
+				},
+				{
+					tag: '540',
+					ind1: ' ',
+					ind2: ' ',
+					subfields: [
+						{code: 'a', value: 'Aineisto on käytettävissä tutkimus- ja muihin tarkoituksiin;'},
+						{code: 'b', value: 'Kansalliskirjasto;'},
+						{code: 'c', value: 'Laki kulttuuriaineistojen tallettamisesta ja säilyttämisestä'},
+						{code: 'u', value: 'http://www.finlex.fi/fi/laki/ajantasa/2007/20071433'},
+						{code: '5', value: 'FI-Vapaa'},
+						{code: '9', value: 'FENNI<KEEP>'}
+					]
+				}
+			]);
+		});
+	});
+
+	describe('#fix', () => {
+		it('Creates access rights fields for record with URN', async () => {
+			const validator = await validatorFactory();
+			const record = new MarcRecord({
+				fields: [
+					{
+						tag: '856',
+						ind1: '4',
+						ind2: '0',
+						subfields: [{code: 'u', value: 'http://urn.fi/URN:ISBN:978-951-9155-47-0'}]
+					}
+				]
+			});
+
+			await validator.fix(record);
+
+			expect(record.fields).to.eql([
+				{
+					tag: '506',
+					ind1: '1',
+					ind2: ' ',
+					subfields: [
+						{code: 'a', value: 'Aineisto on käytettävissä vapaakappalekirjastoissa.'},
+						{code: 'f', value: 'Online access with authorization.'},
+						{code: '2', value: 'star'},
+						{code: '5', value: 'FI-Vapaa'},
+						{code: '9', value: 'FENNI<KEEP>'}
+					]
+				},
+				{
+					tag: '540',
+					ind1: ' ',
+					ind2: ' ',
+					subfields: [
+						{code: 'a', value: 'Aineisto on käytettävissä tutkimus- ja muihin tarkoituksiin;'},
+						{code: 'b', value: 'Kansalliskirjasto;'},
+						{code: 'c', value: 'Laki kulttuuriaineistojen tallettamisesta ja säilyttämisestä'},
+						{code: 'u', value: 'http://www.finlex.fi/fi/laki/ajantasa/2007/20071433'},
+						{code: '5', value: 'FI-Vapaa'},
+						{code: '9', value: 'FENNI<KEEP>'}
+					]
+				},
+				{
+					tag: '856',
+					ind1: '4',
+					ind2: '0',
+					subfields: [
+						{code: 'u', value: 'http://urn.fi/URN:ISBN:978-951-9155-47-0'},
+						{code: 'z', value: 'Käytettävissä vapaakappalekirjastoissa'},
+						{code: '5', value: 'FI-Vapaa'}
+					]
+				}
+			]);
+		});
+	});
+});

--- a/src/ending-punctuation-conf.js
+++ b/src/ending-punctuation-conf.js
@@ -387,7 +387,7 @@ const confSpec = [
 		rangeStart: 540,
 		rangeEnd: 541,
 		index: null,
-		punc: true,
+		punc: false,
 		special: null
 	}, { //	542	EI
 		rangeStart: null,

--- a/src/ending-punctuation-conf.js
+++ b/src/ending-punctuation-conf.js
@@ -387,8 +387,10 @@ const confSpec = [
 		rangeStart: 540,
 		rangeEnd: 541,
 		index: null,
-		punc: false,
-		special: null
+		punc: true,
+		special: {
+			secondLastIfLast: '5'
+		}
 	}, { //	542	EI
 		rangeStart: null,
 		rangeEnd: null,

--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,7 @@
 
 'use strict';
 
+import AccessRights from './access-rights';
 import DoubleCommas from './double-commas';
 import DuplicatesInd1 from './duplicates-ind1';
 import EmptyFields from './empty-fields';
@@ -48,6 +49,7 @@ import UnicodeDecomposition from './unicode-decomposition';
 import Urn from './urn';
 
 export {
+	AccessRights,
 	DoubleCommas,
 	DuplicatesInd1,
 	EmptyFields,

--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,7 @@ import ResolvableExtReferences from './resolvable-ext-references-melinda';
 import SortTags from './sort-tags';
 import SubfieldExclusion from './subfield-exclusion';
 import UnicodeDecomposition from './unicode-decomposition';
+import Urn from './urn';
 
 export {
 	DoubleCommas,
@@ -61,5 +62,6 @@ export {
 	ResolvableExtReferences,
 	SortTags,
 	SubfieldExclusion,
-	UnicodeDecomposition
+	UnicodeDecomposition,
+	Urn
 };

--- a/src/urn.js
+++ b/src/urn.js
@@ -36,7 +36,7 @@ const URN_GENERATOR_URL = 'http://generator.urn.fi/cgi-bin/urn_generator.cgi?typ
 
 export default async function () {
 	async function fix(record) {
-		let URN = ''
+		let URN = '';
 		const isbn = record.fields.reduce((acc, f) => {
 			if (f.tag === '020') {
 				const a = f.subfields.find(sf => sf.code === 'a');
@@ -46,7 +46,7 @@ export default async function () {
 
 			return acc;
 		}, undefined);
-	
+
 		if (isbn) {
 			URN = 'http://urn.fi/URN:ISBN:' + isbn;
 		} else {
@@ -54,7 +54,7 @@ export default async function () {
 			const body = await response.text();
 			URN = 'http://urn.fi/' + body;
 		}
-			
+
 		record.insertField({
 			tag: '856',
 			ind1: '4',
@@ -72,7 +72,7 @@ export default async function () {
 	return {
 		description: 'Adds URN for record, to 856-field (if not existing)',
 		validate: async record => ({
-			valid: !record.get(/^856$/)
+			valid: record.fields.some(sf => sf.tag === '856')
 		}),
 		fix
 	};

--- a/src/urn.js
+++ b/src/urn.js
@@ -1,0 +1,87 @@
+/**
+ *
+ * @licstart  The following is the entire license notice for the JavaScript code in this file.
+ *
+ * MARC record validators used in Melinda
+ *
+ * Copyright (c) 2014-2019 University Of Helsinki (The National Library Of Finland)
+ *
+ * This file is part of marc-record-validators-melinda
+ *
+ * marc-record-validators-melinda program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * marc-record-validators-melinda is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @licend  The above is the entire license notice
+ * for the JavaScript code in this file.
+ *
+ */
+
+/* eslint-disable require-await */
+
+'use strict';
+
+import fetch from 'node-fetch';
+
+const URN_GENERATOR_URL = 'http://generator.urn.fi/cgi-bin/urn_generator.cgi?type=nbn';
+
+export default async function () {
+	async function fix(record) {
+		record.get(/^856$/).some(f => f.subfields.filter(sf => sf.code === 'u').forEach(async sf => {
+			const isbn = record.fields.reduce((acc, f) => {
+				if (f.tag === '020') {
+					const a = f.subfields.find(sf => sf.code === 'a');
+					acc = a ? a.value : undefined;
+					return acc;
+				}
+
+				return acc;
+			}, undefined);
+			if (isbn) {
+				sf.value = 'http://urn.fi/URN:ISBN:' + isbn;
+			} else {
+				const response = await fetch(URN_GENERATOR_URL);
+				const body = await response.text();
+				sf.value = body;
+			}
+
+			return true;
+		}));
+	}
+
+	return {
+		description: 'Handles URN in 856$u-subfields',
+		validate: async record => ({
+			valid: !record
+				.get(/^856$/)
+				.some(f =>
+					f.subfields.some(sf => sf.code === 'u' && sf.value === 'URN')
+				)
+		}),
+		fix
+	};/* : async record =>
+			record.get(/^856$/).some(f =>
+				f.subfields.filter(sf => sf.code === 'u').forEach(sf => {
+					f020 = record.get(/^020$/);
+					console.log(f020);
+					//if (isbn) {
+					//	sf.value = 'http://urn.fi/URN:ISBN:' + isbn;
+					//} else {
+
+					//const response = await fetch(URN_GENERATOR_URL);
+					const body = "bla";//await response.text();
+					sf.value = body;
+					//sf.value = createURN();
+				})
+			)
+	}; */
+}

--- a/src/urn.js
+++ b/src/urn.js
@@ -51,7 +51,7 @@ export default async function () {
 			} else {
 				const response = await fetch(URN_GENERATOR_URL);
 				const body = await response.text();
-				sf.value = body;
+				sf.value = 'http://urn.fi/' + body;
 			}
 
 			return true;

--- a/src/urn.js
+++ b/src/urn.js
@@ -68,20 +68,5 @@ export default async function () {
 				)
 		}),
 		fix
-	};/* : async record =>
-			record.get(/^856$/).some(f =>
-				f.subfields.filter(sf => sf.code === 'u').forEach(sf => {
-					f020 = record.get(/^020$/);
-					console.log(f020);
-					//if (isbn) {
-					//	sf.value = 'http://urn.fi/URN:ISBN:' + isbn;
-					//} else {
-
-					//const response = await fetch(URN_GENERATOR_URL);
-					const body = "bla";//await response.text();
-					sf.value = body;
-					//sf.value = createURN();
-				})
-			)
-	}; */
+	};
 }

--- a/src/urn.js
+++ b/src/urn.js
@@ -36,7 +36,6 @@ const URN_GENERATOR_URL = 'http://generator.urn.fi/cgi-bin/urn_generator.cgi?typ
 
 export default async function () {
 	async function fix(record) {
-		let URN = '';
 		const isbn = record.fields.reduce((acc, f) => {
 			if (f.tag === '020') {
 				const a = f.subfields.find(sf => sf.code === 'a');
@@ -47,12 +46,14 @@ export default async function () {
 			return acc;
 		}, undefined);
 
-		if (isbn) {
-			URN = 'http://urn.fi/URN:ISBN:' + isbn;
-		} else {
+		async function createURN(isbn = false) {
+			if (isbn) {
+				return 'http://urn.fi/URN:ISBN:' + isbn;
+			}
+
 			const response = await fetch(URN_GENERATOR_URL);
 			const body = await response.text();
-			URN = 'http://urn.fi/' + body;
+			return 'http://urn.fi/' + body;
 		}
 
 		record.insertField({
@@ -60,7 +61,7 @@ export default async function () {
 			ind1: '4',
 			ind2: '0',
 			subfields: [
-				{code: 'u', value: URN}
+				{code: 'u', value: await createURN(isbn)}
 			]
 		});
 

--- a/src/urn.js
+++ b/src/urn.js
@@ -46,6 +46,15 @@ export default async function () {
 			return acc;
 		}, undefined);
 
+		record.insertField({
+			tag: '856',
+			ind1: '4',
+			ind2: '0',
+			subfields: [
+				{code: 'u', value: await createURN(isbn)}
+			]
+		});
+
 		async function createURN(isbn = false) {
 			if (isbn) {
 				return 'http://urn.fi/URN:ISBN:' + isbn;
@@ -55,15 +64,6 @@ export default async function () {
 			const body = await response.text();
 			return 'http://urn.fi/' + body;
 		}
-
-		record.insertField({
-			tag: '856',
-			ind1: '4',
-			ind2: '0',
-			subfields: [
-				{code: 'u', value: await createURN(isbn)}
-			]
-		});
 
 		return true;
 	}

--- a/src/urn.spec.js
+++ b/src/urn.spec.js
@@ -104,9 +104,7 @@ describe('urn', () => {
 				]
 				},
 				{tag: '856', ind1: '4', ind2: '0', subfields: [
-					{code: 'u', value: 'http://urn.fi/URN:ISBN:978-951-9155-47-0'},
-					{code: 'z', value: 'Käytettävissä vapaakappalekirjastoissa'},
-					{code: '5', value: 'FI-Vapaa'}
+					{code: 'u', value: 'http://urn.fi/URN:ISBN:978-951-9155-47-0'}
 				]
 				}
 			]);

--- a/src/urn.spec.js
+++ b/src/urn.spec.js
@@ -32,7 +32,7 @@
 
 import {expect} from 'chai';
 import {MarcRecord} from '@natlibfi/marc-record';
-import validatorFactory from '../src/isbn-issn';
+import validatorFactory from '../src/urn';
 
 describe('urn', () => {
 	it('Creates a validator', async () => {

--- a/src/urn.spec.js
+++ b/src/urn.spec.js
@@ -78,9 +78,7 @@ describe('urn', () => {
 			});
 			const result = await validator.validate(record);
 
-			expect(result).to.eql({valid: false, messages: [
-				'URN URN is not valid'
-			]});
+			expect(result).to.eql({valid: false});
 		});
 	});
 
@@ -89,30 +87,31 @@ describe('urn', () => {
 			const validator = await validatorFactory();
 			const record = new MarcRecord({
 				fields: [
-				{
-					tag: '020', 
-					ind1: ' ', 
-					ind2: ' ',
-					subfields: [{code: 'a', value: '978-951-9155-47-0'}]
-				},
-				{
-					tag: '856',
-					ind1: ' ',
-					ind2: ' ',
-					subfields: [{code: 'u', value: 'URN'}]
-				}]
+					{
+						tag: '020',
+						ind1: ' ',
+						ind2: ' ',
+						subfields: [{code: 'a', value: '978-951-9155-47-0'}]
+					},
+					{
+						tag: '856',
+						ind1: ' ',
+						ind2: ' ',
+						subfields: [{code: 'u', value: 'URN'}]
+					}
+				]
 			});
 
 			await validator.fix(record);
 
-			expect(record.fields).to.eql([{
-				tag: '020',	ind1: ' ', ind2: ' ', subfields: [
-					{code: 'a', value: '978-951-9155-47-0'}
-				]},
+			expect(record.fields).to.eql([
+				{tag: '020',	ind1: ' ', ind2: ' ', subfields: [
+					{code: 'a', value: '978-951-9155-47-0'} ]
+				},
 				{tag: '856', ind1: ' ', ind2: ' ', subfields: [
-					{code: 'u', value: 'http://urn.fi/URN:ISBN:978-951-9155-47-0'}
-				]
-			}]);
+					{code: 'u', value: 'http://urn.fi/URN:ISBN:978-951-9155-47-0'} ]
+				}
+			]);
 		});
 	});
 });

--- a/src/urn.spec.js
+++ b/src/urn.spec.js
@@ -1,0 +1,114 @@
+/**
+ *
+ * @licstart  The following is the entire license notice for the JavaScript code in this file.
+ *
+ * MARC record validators used in Melinda
+ *
+ * Copyright (c) 2014-2019 University Of Helsinki (The National Library Of Finland)
+ *
+ * This file is part of marc-record-validators-melinda
+ *
+ * marc-record-validators-melinda program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * marc-record-validators-melinda is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @licend  The above is the entire license notice
+ * for the JavaScript code in this file.
+ *
+ */
+
+/* eslint-disable no-undef, max-nested-callbacks, no-unused-expressions */
+
+'use strict';
+
+import {expect} from 'chai';
+import {MarcRecord} from '@natlibfi/marc-record';
+import validatorFactory from '../src/isbn-issn';
+
+describe('urn', () => {
+	it('Creates a validator', async () => {
+		const validator = await validatorFactory();
+
+		expect(validator)
+			.to.be.an('object')
+			.that.has.any.keys('description', 'validate');
+
+		expect(validator.description).to.be.a('string');
+		expect(validator.validate).to.be.a('function');
+	});
+
+	describe('#validate', () => {
+		it('Finds the record valid', async () => {
+			const validator = await validatorFactory();
+			const record = new MarcRecord({
+				fields: [
+					{
+						tag: '856',
+						ind1: ' ',
+						ind2: ' ',
+						subfields: [{code: 'u', value: 'http://urn.fi/URN:ISBN:978-951-9155-47-0'}]
+					}
+				]
+			});
+			const result = await validator.validate(record);
+
+			expect(result).to.eql({valid: true});
+		});
+
+		it('Finds the record invalid', async () => {
+			const validator = await validatorFactory();
+			const record = new MarcRecord({
+				fields: [
+					{
+						tag: '856',
+						ind1: ' ',
+						ind2: ' ',
+						subfields: [{code: 'u', value: 'URN'}]
+					}
+				]
+			});
+			const result = await validator.validate(record);
+
+			expect(result).to.eql({valid: false, messages: [
+				'URN URN is not valid'
+			]});
+		});
+	});
+
+	describe('#fix', () => {
+		it('Creates URN from 020-field', async () => {
+			const validator = await validatorFactory();
+			const record = new MarcRecord({
+				fields: [
+					{tag: '020', 
+					ind1: ' ', 
+					ind2: ' ',
+					subfields: [{code: 'a', value: '978-951-9155-47-0'}]
+				},
+				{
+					tag: '856',
+					ind1: ' ',
+					ind2: ' ',
+					subfields: [{code: 'u', value: 'URN'}]
+				}]
+			});
+
+			await validator.fix(record);
+
+			expect(record.fields).to.eql([{
+				tag: '856', ind1: ' ', ind2: ' ', subfields: [
+					{code: 'u', value: 'http://urn.fi/URN:ISBN:978-951-9155-47-0'}
+				]
+			}]);
+		});
+	});
+});

--- a/src/urn.spec.js
+++ b/src/urn.spec.js
@@ -89,7 +89,8 @@ describe('urn', () => {
 			const validator = await validatorFactory();
 			const record = new MarcRecord({
 				fields: [
-					{tag: '020', 
+				{
+					tag: '020', 
 					ind1: ' ', 
 					ind2: ' ',
 					subfields: [{code: 'a', value: '978-951-9155-47-0'}]
@@ -105,7 +106,10 @@ describe('urn', () => {
 			await validator.fix(record);
 
 			expect(record.fields).to.eql([{
-				tag: '856', ind1: ' ', ind2: ' ', subfields: [
+				tag: '020',	ind1: ' ', ind2: ' ', subfields: [
+					{code: 'a', value: '978-951-9155-47-0'}
+				]},
+				{tag: '856', ind1: ' ', ind2: ' ', subfields: [
 					{code: 'u', value: 'http://urn.fi/URN:ISBN:978-951-9155-47-0'}
 				]
 			}]);

--- a/src/urn.spec.js
+++ b/src/urn.spec.js
@@ -53,8 +53,8 @@ describe('urn', () => {
 				fields: [
 					{
 						tag: '856',
-						ind1: ' ',
-						ind2: ' ',
+						ind1: '4',
+						ind2: '0',
 						subfields: [{code: 'u', value: 'http://urn.fi/URN:ISBN:978-951-9155-47-0'}]
 					}
 				]
@@ -69,10 +69,10 @@ describe('urn', () => {
 			const record = new MarcRecord({
 				fields: [
 					{
-						tag: '856',
+						tag: '020',
 						ind1: ' ',
 						ind2: ' ',
-						subfields: [{code: 'u', value: 'URN'}]
+						subfields: [{code: 'a', value: '978-951-9155-47-0'}]
 					}
 				]
 			});
@@ -92,12 +92,6 @@ describe('urn', () => {
 						ind1: ' ',
 						ind2: ' ',
 						subfields: [{code: 'a', value: '978-951-9155-47-0'}]
-					},
-					{
-						tag: '856',
-						ind1: ' ',
-						ind2: ' ',
-						subfields: [{code: 'u', value: 'URN'}]
 					}
 				]
 			});
@@ -106,10 +100,14 @@ describe('urn', () => {
 
 			expect(record.fields).to.eql([
 				{tag: '020',	ind1: ' ', ind2: ' ', subfields: [
-					{code: 'a', value: '978-951-9155-47-0'} ]
+					{code: 'a', value: '978-951-9155-47-0'}
+				]
 				},
-				{tag: '856', ind1: ' ', ind2: ' ', subfields: [
-					{code: 'u', value: 'http://urn.fi/URN:ISBN:978-951-9155-47-0'} ]
+				{tag: '856', ind1: '4', ind2: '0', subfields: [
+					{code: 'u', value: 'http://urn.fi/URN:ISBN:978-951-9155-47-0'},
+					{code: 'z', value: 'Käytettävissä vapaakappalekirjastoissa'},
+					{code: '5', value: 'FI-Vapaa'}
+				]
 				}
 			]);
 		});


### PR DESCRIPTION
Adds (hyphenated) ISBN for URN from 020 field.
If 020 is not valid, requests from the URN generator.

This is done if 856$u field has 'URN' in it. (Transformer now creates such preliminary field so validator can repair it, and this is because ISBN should first be hyphenated and then added to URN) 