### PR TITLE
ending punctuation fix for 540-541 fields, added new special rule

### DIFF
--- a/src/ending-punctuation-conf.js
+++ b/src/ending-punctuation-conf.js
@@ -389,7 +389,7 @@ const confSpec = [
 		index: null,
 		punc: true,
 		special: {
-			secondLastIfLast: '5'
+			noPuncIfField: 'u'
 		}
 	}, { //	542	EI
 		rangeStart: null,

--- a/src/ending-punctuation.js
+++ b/src/ending-punctuation.js
@@ -128,6 +128,11 @@ export default async function () {
 						normalPuncRules(lastSubField, !res.punc, tag, true);
 					}
 				}
+			} else if (res.special.noPuncIfField) {
+				if (field.subfields.some(subField => subField.code === res.special.noPuncIfField) === false) {
+					lastSubField = findLastSubfield(field);
+					normalPuncRules(lastSubField, res.punc, tag, true)
+				}
 			} else if (res.special.ifBoth) {
 				lastSubField = findLastSubfield(field);
 				if (lastSubField && lastSubField.code === res.special.puncSubField) {


### PR DESCRIPTION
There was no option for "if field x exists, don't punctuate" so I added it and updated rule 540-541