### PR TITLE
Punc single field

### DIFF
--- a/src/ending-punctuation-conf.js
+++ b/src/ending-punctuation-conf.js
@@ -161,10 +161,30 @@ const confSpec = [
 		index: 250,
 		punc: true,
 		special: null
-	}, { //	254-258	KYLLÄ
+	}, { // 251	EI
+		rangeStart: null,
+		rangeEnd: null,
+		index: 251,
+		punc: false,
+		special: null
+	}, { //	254-256	KYLLÄ
 		rangeStart: 254,
-		rangeEnd: 258,
+		rangeEnd: 256,
 		index: null,
+		punc: true,
+		special: null
+	}, { //	257
+		rangeStart: null,
+		rangeEnd: null,
+		index: 257,
+		punc: true,
+		special: {
+			noPuncIfField: '2'
+		}
+	}, { //	258	KYLLÄ
+		rangeStart: null,
+		rangeEnd: null,
+		index: 258,
 		punc: true,
 		special: null
 	}, { //	260	KYLLÄ	Pääsääntö: $a : $b, $c. Tarkista eri poikkeukset ja välimerkitys MARC 21 Full -versiosta

--- a/src/ending-punctuation-conf.js
+++ b/src/ending-punctuation-conf.js
@@ -250,8 +250,8 @@ const confSpec = [
 		index: 321,
 		punc: false,
 		special: null
-	}, { //	336-338	EI
-		rangeStart: 336,
+	}, { //	335-338	EI
+		rangeStart: 335,
 		rangeEnd: 338,
 		index: null,
 		punc: false,

--- a/src/ending-punctuation.js
+++ b/src/ending-punctuation.js
@@ -33,9 +33,9 @@
 import {validPuncMarks, finnishTerms, confSpec} from './ending-punctuation-conf';
 import createDebugLogger from 'debug';
 
-export default async function () {
-	const debug = createDebugLogger('@natlibfi/marc-record-validator-melinda/ending-punctuation');
+const debug = createDebugLogger('@natlibfi/marc-record-validator-melinda/ending-punctuation');
 
+export default async function () {
 	return {
 		description:
 		'Handles invalid ending punctuation',
@@ -71,7 +71,6 @@ export default async function () {
 
 // Field validation with punctuation rules for normal and special cases in subfunction (to reduce complexity to please travisci)
 function validateField(field, linkedTag, fix, message) {
-
 	// This is used to find last subfield that should have punctuation
 	function findLastSubfield(field) {
 		const subfields = field.subfields.filter(sf => isNaN(sf.code) && 'value' in sf);
@@ -257,13 +256,14 @@ function validateField(field, linkedTag, fix, message) {
 }
 
 export function validateSingleField(field, linkedTag, fix) {
-    const message = {};
-    // process.stdout.write("validateSingleField()");
-    message.message = [];
-    if (fix) {
+	const message = {};
+	message.message = [];
+	if (fix) {
 		message.fix = [];
-    }
-    validateField(field, linkedTag, fix, message);
-    message.valid = !(message.message.length >= 1);
-    return message;
+	}
+
+	validateField(field, linkedTag, fix, message);
+	message.valid = !(message.message.length >= 1);
+	return message;
 }
+

--- a/src/ending-punctuation.js
+++ b/src/ending-punctuation.js
@@ -121,15 +121,15 @@ export default async function () {
 					}
 
 					if (lastSubField.code === res.special.afterOnly) {
-						normalPuncRules(lastSubField, res.punc, tag, res.special.strict);
+						normalPuncRules(lastSubField, res.punc, tag, res.special.strict, false);
 					} else {
-						normalPuncRules(lastSubField, !res.punc, tag, true);
+						normalPuncRules(lastSubField, !res.punc, tag, true, false);
 					}
 				}
 			} else if (res.special.noPuncIfField) {
 				if (field.subfields.some(subField => subField.code === res.special.noPuncIfField) === false) {
 					lastSubField = findLastSubfield(field);
-					normalPuncRules(lastSubField, res.punc, tag, true);
+					normalPuncRules(lastSubField, res.punc, tag, true, false);
 				}
 			} else if (res.special.ifBoth) {
 				lastSubField = findLastSubfield(field);
@@ -154,10 +154,10 @@ export default async function () {
 					} // Not control field
 
 					if (typeof (res.special.last) !== 'undefined' && res.special.secondLastIfLast === subField.code) {
-						normalPuncRules(subField, res.special.last, tag, true);
+						normalPuncRules(subField, res.special.last, tag, true, false);
 					} // Strict because this field should not be abbreviation
 				});
-				normalPuncRules(lastSubField, res.punc, tag, false);
+				normalPuncRules(lastSubField, res.punc, tag, false, false);
 
 				// Search for Finnish terms
 			} else if (res.special.termField) {
@@ -167,9 +167,9 @@ export default async function () {
 					const languageField = field.subfields.find(({code}) => code === res.special.termField);
 					if (languageField && languageField.value && finnishTerms.some(p => p.test(languageField.value))) {
 					// If (languageField && languageField.value && finnishTerms.indexOf(languageField.value) > -1) {
-						normalPuncRules(lastSubField, res.punc, tag, true);
+						normalPuncRules(lastSubField, res.punc, tag, true, false);
 					} else {
-						normalPuncRules(lastSubField, res.special.else, tag, false); // Strict because of years etc (648, 650)
+						normalPuncRules(lastSubField, res.special.else, tag, false, false); // Strict because of years etc (648, 650)
 					}
 				}
 				// Search last of array in subfields and check if it has punc
@@ -181,12 +181,12 @@ export default async function () {
 					} // Not control field
 
 					if (res.special.mandatory && res.special.mandatory.indexOf(subField.code) > -1) {
-						normalPuncRules(subField, res.punc, tag, true);
+						normalPuncRules(subField, res.punc, tag, true, false);
 					} // Strict because of mandatory
 				});
 
 				if (lastSubField) {
-					normalPuncRules(lastSubField, res.punc, tag, false);
+					normalPuncRules(lastSubField, res.punc, tag, false, false);
 				}
 
 				// If field has linked rules (tag: 880), find rules and re-validate
@@ -242,7 +242,7 @@ export default async function () {
 				lastSubField = findLastSubfield(field);
 
 				if (lastSubField) {
-					normalPuncRules(lastSubField, res.punc, field.tag, false);
+					normalPuncRules(lastSubField, res.punc, field.tag, false, false);
 				}
 			} else {
 				try {

--- a/src/ending-punctuation.js
+++ b/src/ending-punctuation.js
@@ -61,7 +61,7 @@ export default async function () {
 		}
 
 		record.fields.forEach(field => {
-			validateField(field);
+			validateField(field, false, fix, message);
 		});
 
 		message.valid = !(message.message.length >= 1);
@@ -203,7 +203,7 @@ function validateField(field, linkedTag, fix, message) {
 				return false;
 			}
 
-			validateField(field, linkedTag);
+			validateField(field, linkedTag, fix, message);
 		}
 	}
 


### PR DESCRIPTION
This branch adds a new exportable function validateSingleField() to ending-punctuation.js and refactors nested functions (so that the new function and the default function) can share them. Also configurations for ending punctuation were updated to accomodate the new field 335 and change in specs for field 257.