### PR TITLE
Generic fix composition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@natlibfi/marc-record": "^7.0.0",
         "@natlibfi/marc-record-validate": "^7.0.1",
         "cld3-asm": "^3.1.1",
+        "clone": "^2.1.2",
         "debug": "^4.3.3",
         "isbn3": "^1.1.18",
         "langs": "^2.0.0",
@@ -2504,6 +2505,14 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/clone-deep": {
@@ -7714,6 +7723,11 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
       }
+    },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
     },
     "clone-deep": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "isbn3": "^1.1.18",
     "langs": "^2.0.0",
     "node-fetch": "^2.6.7",
-    "xml2js": ">=0.4.23 <1.0.0"
+    "xml2js": ">=0.4.23 <1.0.0",
+    "clone": "^2.1.2"
   },
   "peerDependencies": {
     "@natlibfi/marc-record-validate": "^7.0.1"

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import FieldExclusion from './field-exclusion';
 import IdenticalFields from './identical-fields';
 import IsbnIssn from './isbn-issn';
 import ItemLanguage from './item-language';
+import NormalizeUTF8Diacritics from './normalize-utf8-diacritics';
 import Punctuation from './punctuation/';
 import ResolvableExtReferences from './resolvable-ext-references-melinda';
 import SortTags from './sort-tags';
@@ -30,6 +31,7 @@ export {
   IdenticalFields,
   IsbnIssn,
   ItemLanguage,
+  NormalizeUTF8Diacritics,
   Punctuation,
   ResolvableExtReferences,
   SortTags,

--- a/src/normalize-utf8-diacritics.js
+++ b/src/normalize-utf8-diacritics.js
@@ -1,0 +1,149 @@
+//import createDebugLogger from 'debug';
+import clone from 'clone';
+import {convert as nongenericNormalization} from './unicode-decomposition';
+
+// Note that https://github.com/NatLibFi/marc-record-validators-melinda/blob/master/src/unicode-decomposition.js contains
+// similar functionalities. It's less generic and lacks diacritic removal but has it advantages as well.
+
+//const debug = createDebugLogger('@natlibfi/melinda-marc-record-merge-reducers/reducers/normalizeEncoding');
+
+// See also https://github.com/NatLibFi/marc-record-validators-melinda/blob/master/src/unicode-decomposition.js .
+// It uses a list of convertable characters whilst this uses a generic stuff as well.
+// It handles various '.' and '©' type normalizations as well.
+// NB! This version has minor bug/feature issue regarding fixComposition()
+
+// Author(s): Nicholas Volk
+export default function () {
+
+  return {
+    description: 'Generic normalization of latin UTF-8 diacritics. Precompose Finnish å, ä and ö. Decompose others.',
+    validate, fix
+  };
+
+  function fix(record) {
+    const res = {message: [], fix: [], valid: true};
+    //message.fix = []; // eslint-disable-line functional/immutable-data
+
+    // Actual parsing of all fields
+    /*
+    if (!record.fields) {
+      return false;
+    }
+    */
+
+    record.fields.forEach(field => {
+      fieldFixComposition(field);
+      //validateField(field, true, message);
+    });
+
+    // message.valid = !(message.message.length >= 1); // eslint-disable-line functional/immutable-data
+    return res;
+  }
+
+  function validate(record) {
+    const res = {message: []};
+
+    // Actual parsing of all fields
+    /*
+    if (!record.fields) {
+      return false;
+    }
+    */
+
+    record.fields.forEach(field => {
+      validateField(field, res);
+    });
+
+    res.valid = !(res.message.length >= 1); // eslint-disable-line functional/immutable-data
+    return res;
+  }
+
+  function validateField(field, res) {
+    if (!field.subfields) {
+      return;
+    }
+    const orig = fieldToString(field);
+
+    const normalizedField = fieldFixComposition(clone(field));
+    const mod = fieldToString(normalizedField);
+    if (orig !== mod) { // Fail as the input is "broken"/"crap"/sumthing
+      res.message.push(`'${orig}' requires normalization`); // eslint-disable-line functional/immutable-data
+      return;
+    }
+    return;
+  }
+
+  function fieldToString(f) {
+    return `${f.tag} ${f.ind1}${f.ind2} ‡${formatSubfields(f)}`;
+
+    function formatSubfields(field) {
+      //return field.subfields.map(sf => `${sf.code}${sf.value || ''}`).join('‡');
+      return field.subfields.map(sf => `${sf.code}${sf.value}`).join('‡');
+    }
+  }
+}
+
+
+// Traditionally these six are precomposed and all the rest decomposed
+function precomposeFinnishLetters(value = '') {
+  return value.
+    replace(/å/gu, 'å').
+    replace(/ä/gu, 'ä').
+    replace(/ö/gu, 'ö').
+    replace(/Å/gu, 'Å').
+    replace(/Ä/gu, 'Ä').
+    replace(/Ö/gu, 'Ö');
+}
+
+function fixComposition(value = '') {
+  // Target: Diacritics use Melinda internal notation.
+  // General solution: Decompose everything and then compose 'å', 'ä', 'ö', 'Å', 'Ä' and 'Ö'.
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize
+  // Bug/Feature: the generic normalize() function also normalizes non-latin encodings as well, is this ok?
+  // Exception: Input contains non-Latin script letters: don't decompose (see field 880 tests):
+  if (value.match(/[^\p{Script=Latin}\p{Script=Common}\p{Script=Inherited}]/u)) {
+    // Problem with this approach: mixed language content (eg. cyrillic + latin) won't get normalized.
+    // Hack/Damage control: we might add decomposition rules for most common diacritis here (eg. ü, é...).
+    // OR we could split input to words and handle them separately?
+    // NB! Hack not implemented yet. The main source of problematic case would probably be greek characters
+    // within texts, that are written with latin alphabet.
+    //return precomposeFinnishLetters(value);
+    return nongenericNormalization(value);
+  }
+  return precomposeFinnishLetters(String(value).normalize('NFD'));
+}
+
+
+export function fieldFixComposition(field) {
+  if (!field.subfields) {
+    return field;
+  }
+  //const originalValue = fieldToString(field);
+  //nvdebug(`fFC: '${originalValue}'`, debug);
+  field.subfields.forEach((subfield, index) => {
+    field.subfields[index].value = fixComposition(subfield.value); // eslint-disable-line functional/immutable-data
+  });
+  //const newValue = fieldToString(field);
+  //if (originalValue !== newValue) { // eslint-disable-line functional/no-conditional-statement
+  //  debug(`FIXCOMP: '${originalValue}' => '${newValue}'`);
+  //}
+  return field;
+}
+
+/*
+export function fieldRemoveDecomposedDiacritics(field) {
+  // Raison d'être/motivation: "Sirén" and diacriticless "Siren" might refer to a same surname, so this normalization
+  // allows us to compare authors and avoid duplicate fields.
+  field.subfields.forEach((sf) => {
+    sf.value = removeDecomposedDiacritics(sf.value); // eslint-disable-line functional/immutable-data
+  });
+
+  function removeDecomposedDiacritics(value = '') {
+    // NB #1: Does nothing to precomposed letters. String.normalize('NFD') can handle them.
+    // NB #2: Finnish letters 'å', 'ä', 'ö', 'Å', Ä', and 'Ö' should be handled (=precomposed) before calling this.
+    // NB #3: Calling our very own fixComposition() before this function handles both #1 and #2.
+    return String(value).replace(/\p{Diacritic}/gu, '');
+  }
+}
+*/
+

--- a/src/normalize-utf8-diacritics.spec.js
+++ b/src/normalize-utf8-diacritics.spec.js
@@ -1,0 +1,52 @@
+import {expect} from 'chai';
+import {MarcRecord} from '@natlibfi/marc-record';
+import validatorFactory from './normalize-utf8-diacritics';
+import {READERS} from '@natlibfi/fixura';
+import generateTests from '@natlibfi/fixugen';
+import createDebugLogger from 'debug';
+
+generateTests({
+  callback,
+  path: [__dirname, '..', 'test-fixtures', 'normalize-utf8-diacritics'],
+  useMetadataFile: true,
+  recurse: false,
+  fixura: {
+    reader: READERS.JSON
+  },
+  mocha: {
+    before: () => testValidatorFactory()
+  }
+});
+const debug = createDebugLogger('@natlibfi/marc-record-validators-melinda/normalize-utf8-diacritics:test');
+
+async function testValidatorFactory() {
+  const validator = await validatorFactory();
+
+  expect(validator)
+    .to.be.an('object')
+    .that.has.any.keys('description', 'validate');
+
+  expect(validator.description).to.be.a('string');
+  expect(validator.validate).to.be.a('function');
+}
+
+async function callback({getFixture, enabled = true, fix = false}) {
+  if (enabled === false) {
+    debug('TEST SKIPPED!');
+    return;
+  }
+
+  const validator = await validatorFactory();
+  const record = new MarcRecord(getFixture('record.json'));
+  const expectedResult = getFixture('expectedResult.json');
+  // console.log(expectedResult); // eslint-disable-line
+
+  if (!fix) {
+    const result = await validator.validate(record);
+    expect(result).to.eql(expectedResult);
+    return;
+  }
+
+  await validator.fix(record);
+  expect(record).to.eql(expectedResult);
+}

--- a/src/unicode-decomposition.js
+++ b/src/unicode-decomposition.js
@@ -136,8 +136,9 @@ export default function () {
       return null;
     });
   }
-
-  function convert(value) {
-    return Object.keys(MAP_CONVERSION).reduce((result, key) => result.includes(key) ? result.replace(new RegExp(key, 'ug'), MAP_CONVERSION[key]) : result, value);
-  }
 }
+
+export function convert(value) {
+  return Object.keys(MAP_CONVERSION).reduce((result, key) => result.includes(key) ? result.replace(new RegExp(key, 'ug'), MAP_CONVERSION[key]) : result, value);
+}
+

--- a/test-fixtures/normalize-utf8-diacritics/01/expectedResult.json
+++ b/test-fixtures/normalize-utf8-diacritics/01/expectedResult.json
@@ -1,0 +1,7 @@
+{
+  "message": [
+    "'100    ‡aSirén, Matti‡ekirjoittaja.' requires normalization",
+    "'245    ‡aÁÈÏÔŨ áèïôũ‡cMatti Sirén.' requires normalization"
+  ],
+  "valid": false
+}

--- a/test-fixtures/normalize-utf8-diacritics/01/metadata.json
+++ b/test-fixtures/normalize-utf8-diacritics/01/metadata.json
@@ -1,0 +1,5 @@
+{
+  "description": "Validate diacritics: fail, since decomposed should precomposed",
+  "enabled": true,
+  "fix": false
+}

--- a/test-fixtures/normalize-utf8-diacritics/01/record.json
+++ b/test-fixtures/normalize-utf8-diacritics/01/record.json
@@ -1,0 +1,39 @@
+{
+  "fields": [
+    {
+      "tag": "005",
+      "value": "20220202020202.0"
+    },
+    {
+      "tag": "100",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Sirén, Matti"
+        },
+        {
+          "code": "e",
+          "value": "kirjoittaja."
+        }
+      ]
+    },
+    {
+      "tag": "245",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "ÁÈÏÔŨ áèïôũ"
+        },
+        {
+          "code": "c",
+          "value": "Matti Sirén."
+        }
+      ]
+    }
+
+  ]
+}

--- a/test-fixtures/normalize-utf8-diacritics/02/expectedResult.json
+++ b/test-fixtures/normalize-utf8-diacritics/02/expectedResult.json
@@ -1,0 +1,41 @@
+{
+  "_validationOptions": {},
+  "leader": "",
+  "fields": [
+    {
+      "tag": "005",
+      "value": "20220202020202.0"
+    },
+    {
+      "tag": "100",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Sirén, Matti"
+        },
+        {
+          "code": "e",
+          "value": "kirjoittaja."
+        }
+      ]
+    },
+    {
+      "tag": "245",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "ÁÈÏÔŨ áèïôũ"
+        },
+        {
+          "code": "c",
+          "value": "Matti Sirén."
+        }
+      ]
+    }
+
+  ]
+}

--- a/test-fixtures/normalize-utf8-diacritics/02/metadata.json
+++ b/test-fixtures/normalize-utf8-diacritics/02/metadata.json
@@ -1,0 +1,5 @@
+{
+  "description": "Fix precomposed -> decomposed",
+  "enabled": true,
+  "fix": true
+}

--- a/test-fixtures/normalize-utf8-diacritics/02/record.json
+++ b/test-fixtures/normalize-utf8-diacritics/02/record.json
@@ -1,0 +1,39 @@
+{
+  "fields": [
+    {
+      "tag": "005",
+      "value": "20220202020202.0"
+    },
+    {
+      "tag": "100",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Sirén, Matti"
+        },
+        {
+          "code": "e",
+          "value": "kirjoittaja."
+        }
+      ]
+    },
+    {
+      "tag": "245",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "ÁÈÏÔŨ áèïôũ"
+        },
+        {
+          "code": "c",
+          "value": "Matti Sirén."
+        }
+      ]
+    }
+
+  ]
+}

--- a/test-fixtures/normalize-utf8-diacritics/03/expectedResult.json
+++ b/test-fixtures/normalize-utf8-diacritics/03/expectedResult.json
@@ -1,0 +1,5 @@
+{
+  "message": [],
+  "valid": true
+}
+

--- a/test-fixtures/normalize-utf8-diacritics/03/metadata.json
+++ b/test-fixtures/normalize-utf8-diacritics/03/metadata.json
@@ -1,0 +1,5 @@
+{
+  "description": "Validate diacritics: success, since only normalized diacritics are used",
+  "enabled": true,
+  "fix": false
+}

--- a/test-fixtures/normalize-utf8-diacritics/03/record.json
+++ b/test-fixtures/normalize-utf8-diacritics/03/record.json
@@ -1,0 +1,37 @@
+{
+  "_validationOptions": {},
+  "leader": "",
+  "fields": [
+    {
+      "tag": "100",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Sirén-Mörkö, Matti"
+        },
+        {
+          "code": "e",
+          "value": "kirjoittaja."
+        }
+      ]
+    },
+    {
+      "tag": "245",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "ÁÈÏÔŨ áèïôũ"
+        },
+        {
+          "code": "c",
+          "value": "Matti Sirén-Mörkö."
+        }
+      ]
+    }
+
+  ]
+}

--- a/test-fixtures/normalize-utf8-diacritics/04/expectedResult.json
+++ b/test-fixtures/normalize-utf8-diacritics/04/expectedResult.json
@@ -1,0 +1,41 @@
+{
+  "_validationOptions": {},
+  "leader": "",
+  "fields": [
+    {
+      "tag": "005",
+      "value": "20220202020202.0"
+    },
+    {
+      "tag": "100",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Sirén, Matti"
+        },
+        {
+          "code": "e",
+          "value": "kirjoittaja."
+        }
+      ]
+    },
+    {
+      "tag": "245",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Latin Á, Cyrillic й"
+        },
+        {
+          "code": "c",
+          "value": "Matti Sirén."
+        }
+      ]
+    }
+
+  ]
+}

--- a/test-fixtures/normalize-utf8-diacritics/04/metadata.json
+++ b/test-fixtures/normalize-utf8-diacritics/04/metadata.json
@@ -1,0 +1,5 @@
+{
+  "description": "Fix precomposed -> decomposed",
+  "enabled": true,
+  "fix": true
+}

--- a/test-fixtures/normalize-utf8-diacritics/04/metadata.json
+++ b/test-fixtures/normalize-utf8-diacritics/04/metadata.json
@@ -1,5 +1,5 @@
 {
-  "description": "Fix precomposed -> decomposed",
+  "description": "Fix using fallback (245$a contains diacritics in both latin and cyrillic letters",
   "enabled": true,
   "fix": true
 }

--- a/test-fixtures/normalize-utf8-diacritics/04/record.json
+++ b/test-fixtures/normalize-utf8-diacritics/04/record.json
@@ -1,0 +1,39 @@
+{
+  "fields": [
+    {
+      "tag": "005",
+      "value": "20220202020202.0"
+    },
+    {
+      "tag": "100",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Sirén, Matti"
+        },
+        {
+          "code": "e",
+          "value": "kirjoittaja."
+        }
+      ]
+    },
+    {
+      "tag": "245",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Latin Á, Cyrillic й"
+        },
+        {
+          "code": "c",
+          "value": "Matti Sirén."
+        }
+      ]
+    }
+
+  ]
+}

--- a/test-fixtures/normalize-utf8-diacritics/05/expectedResult.json
+++ b/test-fixtures/normalize-utf8-diacritics/05/expectedResult.json
@@ -1,0 +1,41 @@
+{
+  "_validationOptions": {},
+  "leader": "",
+  "fields": [
+    {
+      "tag": "005",
+      "value": "20220202020202.0"
+    },
+    {
+      "tag": "100",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Ålander, Väinö"
+        },
+        {
+          "code": "e",
+          "value": "kirjoittaja."
+        }
+      ]
+    },
+    {
+      "tag": "245",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Örkkejä /"
+        },
+        {
+          "code": "c",
+          "value": "Väinö Ålander."
+        }
+      ]
+    }
+
+  ]
+}

--- a/test-fixtures/normalize-utf8-diacritics/05/metadata.json
+++ b/test-fixtures/normalize-utf8-diacritics/05/metadata.json
@@ -1,0 +1,5 @@
+{
+  "description": "Fix decomposed å/ä/ö -> precomposed",
+  "enabled": true,
+  "fix": true
+}

--- a/test-fixtures/normalize-utf8-diacritics/05/record.json
+++ b/test-fixtures/normalize-utf8-diacritics/05/record.json
@@ -1,0 +1,41 @@
+{
+  "_validationOptions": {},
+  "leader": "",
+  "fields": [
+    {
+      "tag": "005",
+      "value": "20220202020202.0"
+    },
+    {
+      "tag": "100",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Ålander, Väinö"
+        },
+        {
+          "code": "e",
+          "value": "kirjoittaja."
+        }
+      ]
+    },
+    {
+      "tag": "245",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Örkkejä /"
+        },
+        {
+          "code": "c",
+          "value": "Väinö Ålander."
+        }
+      ]
+    }
+
+  ]
+}

--- a/test-fixtures/normalize-utf8-diacritics/05/tmp.json
+++ b/test-fixtures/normalize-utf8-diacritics/05/tmp.json
@@ -1,0 +1,41 @@
+{
+  "_validationOptions": {},
+  "leader": "",
+  "fields": [
+    {
+      "tag": "005",
+      "value": "20220202020202.0"
+    },
+    {
+      "tag": "100",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Ålander, Väinö"
+        },
+        {
+          "code": "e",
+          "value": "kirjoittaja."
+        }
+      ]
+    },
+    {
+      "tag": "245",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Örkkejä /"
+        },
+        {
+          "code": "c",
+          "value": "Väinö Ålander."
+        }
+      ]
+    }
+
+  ]
+}


### PR DESCRIPTION
Generic composition validator/fixer for *latin* diaritics + decent tests

(NB! There's already similar non-generic similar validator/fixer "unicode-decomposition". However, there are small differences and thus both should be kept. Also, the new functionality used old non-generic fixer as a fallback in one marginal context.)