### PR TITLE
Added initial version of subfield value ending character validator 

### DIFF
--- a/src/ending-whitespace.js
+++ b/src/ending-whitespace.js
@@ -1,0 +1,36 @@
+/**
+ * Provides interface to validate and fix record fields, which include subfields that end with whitespace character
+ * @returns {Object} Object containing interfaces required by marc-record-validators-melinda package
+ */
+export default function () {
+  return {
+    description: 'Handles subfields that ends with whitespace character',
+    validate,
+    fix
+  };
+
+  function validate(record) {
+    const nonValidFields = record.fields.filter(({subfields}) => subfields.filter(valueEndsWithWhitespace).length > 0);
+
+    const valid = nonValidFields.length === 0;
+    const messages = nonValidFields.flatMap(({tag, subfields}) => subfields.map(sf => `Field ${tag} subfield $${sf.code} ends with whitespace`));
+
+    return valid ? {valid, messages: []} : {valid, messages};
+  }
+
+  /* eslint-disable functional/immutable-data,functional/no-conditional-statement */
+  function fix(record) {
+    record.fields.forEach(({subfields}) => {
+      subfields.forEach(subfield => {
+        if (valueEndsWithWhitespace(subfield)) {
+          subfield.value = subfield.value.trimEnd();
+        }
+      });
+    });
+  }
+  /* eslint-enable functional/immutable-data,functional/no-conditional-statement */
+
+  function valueEndsWithWhitespace({value}) {
+    return (/\s$/u).test(value);
+  }
+}

--- a/src/ending-whitespace.spec.js
+++ b/src/ending-whitespace.spec.js
@@ -1,0 +1,51 @@
+import {expect} from 'chai';
+import {MarcRecord} from '@natlibfi/marc-record';
+import validatorFactory from './ending-whitespace';
+import {READERS} from '@natlibfi/fixura';
+import generateTests from '@natlibfi/fixugen';
+import createDebugLogger from 'debug';
+
+generateTests({
+  callback,
+  path: [__dirname, '..', 'test-fixtures', 'ending-whitespace'],
+  useMetadataFile: true,
+  recurse: false,
+  fixura: {
+    reader: READERS.JSON
+  },
+  mocha: {
+    before: () => testValidatorFactory()
+  }
+});
+const debug = createDebugLogger('@natlibfi/marc-record-validators-melinda/ending-whitespace:test');
+
+async function testValidatorFactory() {
+  const validator = await validatorFactory();
+
+  expect(validator)
+    .to.be.an('object')
+    .that.has.any.keys('description', 'validate');
+
+  expect(validator.description).to.be.a('string');
+  expect(validator.validate).to.be.a('function');
+}
+
+async function callback({getFixture, enabled = true, fix = false}) {
+  if (enabled === false) {
+    debug('TEST SKIPPED!');
+    return;
+  }
+
+  const validator = await validatorFactory();
+  const record = new MarcRecord(getFixture('record.json'));
+  const expectedResult = getFixture('expectedResult.json');
+
+  if (!fix) {
+    const result = await validator.validate(record);
+    expect(result).to.eql(expectedResult);
+    return;
+  }
+
+  await validator.fix(record);
+  expect(record).to.eql(expectedResult);
+}

--- a/test-fixtures/ending-whitespace/01/expectedResult.json
+++ b/test-fixtures/ending-whitespace/01/expectedResult.json
@@ -1,0 +1,4 @@
+{
+  "messages": [],
+  "valid": true
+}

--- a/test-fixtures/ending-whitespace/01/metadata.json
+++ b/test-fixtures/ending-whitespace/01/metadata.json
@@ -1,0 +1,5 @@
+{
+  "description": "Finds the record valid when there are no subfields that end with whitespace",
+  "enabled": true,
+  "fix": false
+}

--- a/test-fixtures/ending-whitespace/01/record.json
+++ b/test-fixtures/ending-whitespace/01/record.json
@@ -1,0 +1,15 @@
+{
+  "fields": [
+    {
+      "tag": "500",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Foo"
+        }
+      ]
+    }
+  ]
+}

--- a/test-fixtures/ending-whitespace/02/expectedResult.json
+++ b/test-fixtures/ending-whitespace/02/expectedResult.json
@@ -1,0 +1,4 @@
+{
+  "messages":["Field 500 subfield $a ends with whitespace"],
+  "valid": false
+}

--- a/test-fixtures/ending-whitespace/02/metadata.json
+++ b/test-fixtures/ending-whitespace/02/metadata.json
@@ -1,0 +1,5 @@
+{
+  "description": "Finds the record not valid when there is a subfield that ends with whitespace",
+  "enabled": true,
+  "fix": false
+}

--- a/test-fixtures/ending-whitespace/02/record.json
+++ b/test-fixtures/ending-whitespace/02/record.json
@@ -1,0 +1,15 @@
+{
+  "fields": [
+    {
+      "tag": "500",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Foo "
+        }
+      ]
+    }
+  ]
+}

--- a/test-fixtures/ending-whitespace/03/expectedResult.json
+++ b/test-fixtures/ending-whitespace/03/expectedResult.json
@@ -1,0 +1,17 @@
+{
+  "_validationOptions": {},
+  "fields": [
+      {
+        "tag": "500",
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
+            "code": "a",
+            "value": "Foo"
+          }
+        ]
+      }
+  ],
+  "leader": ""
+}

--- a/test-fixtures/ending-whitespace/03/metadata.json
+++ b/test-fixtures/ending-whitespace/03/metadata.json
@@ -1,0 +1,5 @@
+{
+  "description": "Fixes the record subfield that ends with whitespace",
+  "enabled": true,
+  "fix": true
+}

--- a/test-fixtures/ending-whitespace/03/record.json
+++ b/test-fixtures/ending-whitespace/03/record.json
@@ -1,0 +1,15 @@
+{
+  "fields": [
+    {
+      "tag": "500",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Foo "
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- Validator validates whether the last character of subfield value is whitespace
- Fix option fixes the subfield value so that all whitespace characters are stripped from the end of subfield value