### PR TITLE
10.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@natlibfi/marc-record-validators-melinda",
-  "version": "9.3.0",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@natlibfi/marc-record-validators-melinda",
-      "version": "9.3.0",
+      "version": "10.0.0",
       "license": "MIT",
       "dependencies": {
         "@babel/register": "^7.18.9",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "git@github.com:natlibfi/marc-record-validators-melinda.git"
   },
   "license": "MIT",
-  "version": "9.3.0",
+  "version": "10.0.0",
   "main": "./dist/index.js",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
A bit late major semantic version change for Node v14 -> Node v18 update.

Note that versions v9.2.0 and v.9.3.0 also require Node v18.