### PR TITLE
New validators related to control subfields (#153)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@natlibfi/marc-record-validators-melinda",
-  "version": "10.0.2",
+  "version": "10.1.0-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@natlibfi/marc-record-validators-melinda",
-      "version": "10.0.2",
+      "version": "10.1.0-alpha.2",
       "license": "MIT",
       "dependencies": {
         "@babel/register": "^7.18.9",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "git@github.com:natlibfi/marc-record-validators-melinda.git"
   },
   "license": "MIT",
-  "version": "10.0.2",
+  "version": "10.1.0-alpha.2",
   "main": "./dist/index.js",
   "publishConfig": {
     "access": "public"

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,10 @@ import IsbnIssn from './isbn-issn';
 import ItemLanguage from './item-language';
 import NormalizeUTF8Diacritics from './normalize-utf8-diacritics';
 import Punctuation from './punctuation/';
+import ResolveOrphanedSubfield6s from './resolveOrphanedSubfield6s'; // Do this before reindexing!
+import ReindexSubfield6OccurenceNumbers from './reindexSubfield6OccurenceNumbers';
 import ResolvableExtReferences from './resolvable-ext-references-melinda';
+
 import SortTags from './sort-tags';
 import SubfieldExclusion from './subfield-exclusion';
 import UnicodeDecomposition from './unicode-decomposition';
@@ -33,6 +36,8 @@ export {
   ItemLanguage,
   NormalizeUTF8Diacritics,
   Punctuation,
+  ResolveOrphanedSubfield6s,
+  ReindexSubfield6OccurenceNumbers,
   ResolvableExtReferences,
   SortTags,
   SubfieldExclusion,

--- a/src/multiple-subfield-0.js
+++ b/src/multiple-subfield-0.js
@@ -1,0 +1,111 @@
+// import createDebugLogger from 'debug';
+// import clone from 'clone';
+// const debug = createDebugLogger('@natlibfi/marc-record-validators-melinda:multiple-subfield-0');
+
+import {fieldHasSubfield, fieldToString} from './utils';
+
+const asteriPrefixes = ['(FI-ASTERI-N)', '(FIN11)', 'http://urn.fi/URN:NBN:fi:au:finaf:', 'https://urn.fi/URN:NBN:fi:au:finaf:'];
+
+export default function () {
+
+  return {
+    description: 'If Asteri subfield $0 is found, remove non-Asteri $0 subfields',
+    validate, fix
+  };
+
+  function fix(record) {
+    function removeNonAsteriSubfields(field) {
+      const removableSubfields = getDeletableSubfields(field.subfields);
+      removableSubfields.forEach(sf => record.removeSubfield(sf, field));
+    }
+
+    const res = {message: [], fix: [], valid: true};
+
+    const relevantFields = getRelevantFields(record);
+
+    relevantFields.forEach(field => removeNonAsteriSubfields(field));
+
+    // message.valid = !(message.message.length >= 1); // eslint-disable-line functional/immutable-data
+    return res;
+  }
+
+  function validate(record) {
+    const relevantFields = getRelevantFields(record);
+    const messages = relevantFields.map(field => `Contains deletable $0 subfield(s): ${fieldToString(field)}`);
+    const res = {message: messages};
+    res.valid = !(res.message.length >= 1); // eslint-disable-line functional/immutable-data
+    return res;
+  }
+
+  function fieldGetSubfields(field, code) {
+    return field.subfields.filter(sf => sf.code === code);
+  }
+
+  function isAsteriId(value) {
+    const nineDigitTail = value.slice(-9);
+    if (!(/^[0-9]{9}$/u).test(nineDigitTail)) {
+      return false;
+    }
+    // Normalize prefix:
+    const currPrefix = value.slice(0, -9);
+
+    if (asteriPrefixes.includes(currPrefix)) {
+      return true;
+    }
+    return false;
+  }
+
+  function getAsteriSubfields(subfields) {
+    return subfields.filter(sf => isAsteriId(sf.value));
+  }
+
+
+  function getDeletableSubfields(subfields) {
+    return subfields.filter(sf => sf.code === '0' && isDeletableId(sf.value));
+
+    function isDeletableId(value) {
+      if (isAsteriId(value)) {
+        return false;
+      }
+      // Bit lazy here, but it's easy to edit, and this should be good enough for proof-of-concept at least
+      if (value.match(/(?:isni|orcid)/ui)) {
+        return true;
+      }
+      // Currently default to false, and delete only specified values
+      return false;
+    }
+  }
+
+  function fieldHasTitlePart(field) {
+    if (['600', '610', '700', '710', '800', '810'].includes(field.tag)) {
+      if (fieldHasSubfield(field, 't')) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function fieldIsRelevant(field) {
+    const subfield0s = fieldGetSubfields(field, '0');
+    if (subfield0s.length < 2) {
+      return false;
+    }
+    const asteriSubfields = getAsteriSubfields(subfield0s);
+    if (asteriSubfields.length < 1) {
+      return false;
+    }
+
+    // $0 might refer to name part or title part. If title part is present, don't remove...
+    if (fieldHasTitlePart(field)) {
+      return false;
+    }
+
+
+    const deletableSubfields = getDeletableSubfields(subfield0s);
+    return deletableSubfields.length > 0;
+  }
+
+  function getRelevantFields(record) {
+    return record.fields.filter(field => field.subfields && fieldIsRelevant(field));
+  }
+}

--- a/src/multiple-subfield-0.spec.js
+++ b/src/multiple-subfield-0.spec.js
@@ -1,15 +1,15 @@
 import {expect} from 'chai';
 import {MarcRecord} from '@natlibfi/marc-record';
-import validatorFactory from './mergeField500Lisapainokset';
+import validatorFactory from './multiple-subfield-0';
 import {READERS} from '@natlibfi/fixura';
 import generateTests from '@natlibfi/fixugen';
 import createDebugLogger from 'debug';
 
 generateTests({
   callback,
-  path: [__dirname, '..', 'test-fixtures', 'lisapainokset'],
+  path: [__dirname, '..', 'test-fixtures', 'subfield0'],
   useMetadataFile: true,
-  recurse: true,
+  recurse: false,
   fixura: {
     reader: READERS.JSON
   },
@@ -17,7 +17,7 @@ generateTests({
     before: () => testValidatorFactory()
   }
 });
-const debug = createDebugLogger('@natlibfi/marc-record-validators-melinda/mergeField500Lisapainokset:test');
+const debug = createDebugLogger('@natlibfi/marc-record-validators-melinda/multiple-subfield-0:test');
 
 async function testValidatorFactory() {
   const validator = await validatorFactory();

--- a/src/normalize-utf8-diacritics.js
+++ b/src/normalize-utf8-diacritics.js
@@ -5,7 +5,7 @@ import {convert as nongenericNormalization} from './unicode-decomposition';
 // Note that https://github.com/NatLibFi/marc-record-validators-melinda/blob/master/src/unicode-decomposition.js contains
 // similar functionalities. It's less generic and lacks diacritic removal but has it advantages as well.
 
-//const debug = createDebugLogger('@natlibfi/melinda-marc-record-merge-reducers/reducers/normalizeEncoding');
+//const debug = createDebugLogger('@natlibfi/melinda-marc-record-merge-reducers/reducers/normalize-utf-diacritics');
 
 // See also https://github.com/NatLibFi/marc-record-validators-melinda/blob/master/src/unicode-decomposition.js .
 // It uses a list of convertable characters whilst this uses a generic stuff as well.

--- a/src/reindexSubfield6OccurenceNumbers.js
+++ b/src/reindexSubfield6OccurenceNumbers.js
@@ -1,0 +1,210 @@
+import createDebugLogger from 'debug';
+import {fieldHasSubfield, fieldToString, nvdebug} from './utils';
+import {fieldGetOccurrenceNumberPairs, fieldGetUnambiguousOccurrenceNumber, intToOccurrenceNumberString, isValidSubfield6,
+  recordGetMaxSubfield6OccurrenceNumberAsInteger, resetFieldOccurrenceNumber,
+  resetSubfield6OccurrenceNumber, subfield6GetOccurrenceNumber, subfield6GetOccurrenceNumberAsInteger} from './subfield6Utils';
+
+// Relocated from melinda-marc-record-merge-reducers (and renamed)
+
+const debug = createDebugLogger('@natlibfi/marc-record-validators-melinda:reindexSubfield6OccurrenceNumbers');
+
+
+// NB! This validator/fixer has two functionalities:
+// 1) normal reindexing of occurrence numbers
+// 2) disambiguation (when possible) of unambiguous occurrence numbers
+
+export default function () {
+  return {
+    description: 'Reindex occurrence numbers in $6 subfield so that they start from 01 and end in NN',
+    validate, fix
+  };
+
+  function fix(record) {
+    nvdebug('Fix SF6 occurrence numbers', debug);
+    const res = {message: [], fix: [], valid: true};
+    //message.fix = []; // eslint-disable-line functional/immutable-data
+
+    // This can not really fail...
+
+    recordDisambiguateSharedSubfield6OccurrenceNumbers(record);
+    recordResetSubfield6OccurrenceNumbers(record);
+
+    // message.valid = !(message.message.length >= 1); // eslint-disable-line functional/immutable-data
+    return res;
+  }
+
+  function validate(record) {
+    const res = {message: []};
+
+    nvdebug('Validate SF6 occurrence number multiuses', debug);
+    if (recordGetSharedOccurrenceNumbers(record).length) { // eslint-disable-line functional/no-conditional-statement
+      res.message.push(`Multi-use of occurrence number(s) detected`); // eslint-disable-line functional/immutable-data
+    }
+
+    // Check max, and check number of different indexes
+    nvdebug('Validate SF6 occurrence number (max vs n instances)', debug);
+    const max = recordGetMaxSubfield6OccurrenceNumberAsInteger(record);
+    const size = recordGetNumberOfUniqueSubfield6OccurrenceNumbers(record);
+
+
+    if (max !== size) { // eslint-disable-line functional/no-conditional-statement
+      res.message.push(`Gaps detected in occurrence numbers: found ${size}, seen max ${max}`); // eslint-disable-line functional/immutable-data
+    }
+    res.valid = res.message.length < 1; // eslint-disable-line functional/immutable-data
+    return res;
+  }
+}
+
+function getPotentialSharedOccurrenceNumberFields(occurrenceNumber, fields) {
+  return fields.filter(f => f.tag !== '880' && f.subfields.some(sf => subfield6GetOccurrenceNumber(sf) === occurrenceNumber));
+}
+
+function subfieldHasSharedOccurrenceNumber(subfield, candFields) {
+  const occurrenceNumber = subfield6GetOccurrenceNumber(subfield);
+  if (!occurrenceNumber || occurrenceNumber === '00') {
+    return false;
+  }
+  const relevantFields = getPotentialSharedOccurrenceNumberFields(occurrenceNumber, candFields);
+  // record.fields.filter(f => f.tag !== '880' && fieldHasOccurrenceNumber(f, occurrenceNumber));
+  return relevantFields.length > 1;
+}
+
+function fieldHasSharedOccurrenceNumber(field, candFields) {
+  if (!field.subfields || field.tag === '880') { // Should not happen
+    return false;
+  }
+
+  // What if there are multiple $6s in a given field? Should not be, but...
+  return field.subfields.some(subfield => subfieldHasSharedOccurrenceNumber(subfield, candFields));
+
+}
+
+function recordGetSharedOccurrenceNumbers(record) {
+  const fieldsContainingSubfield6 = record.fields.filter(field => field.tag !== '880' && fieldHasSubfield(field, '6'));
+  // fieldsContainingSubfield6.some(field => fieldHasSharedOccurrenceNumber(field, fieldsContainingSubfield6)))
+  return fieldsContainingSubfield6.filter(field => fieldHasSharedOccurrenceNumber(field, fieldsContainingSubfield6));
+}
+
+function recordDisambiguateSharedSubfield6OccurrenceNumbers(record) {
+  const sharedOccurrenceNumberFields = recordGetSharedOccurrenceNumbers(record);
+  if (sharedOccurrenceNumberFields.length < 2) {
+    return;
+  }
+  nvdebug(`Disambiguate occurrence numbers (N=${sharedOccurrenceNumberFields.length}) in...`, debug);
+  sharedOccurrenceNumberFields.forEach(field => disambiguateOccurrenceNumber(field));
+
+  function disambiguateable(field) {
+    if (field.tag === '880') { // Not needed, already filtered...
+      return false;
+    }
+    const occurrenceNumber = fieldGetUnambiguousOccurrenceNumber(field);
+    nvdebug(` Trying to disambiguate ${occurrenceNumber} in '${fieldToString(field)}`);
+    if (occurrenceNumber === undefined) {
+      return false;
+    }
+    const allRelevantFields = getPotentialSharedOccurrenceNumberFields(occurrenceNumber, sharedOccurrenceNumberFields);
+    if (allRelevantFields.length < 2) {
+      nvdebug(` Currently only ${allRelevantFields.length} field(s) use occurrence number ${occurrenceNumber}. No action required.`);
+      return false;
+    }
+    nvdebug(` Currently ${allRelevantFields.length} field(s) use occurrence number ${occurrenceNumber}. ACTION REQUIRED!`);
+    const relevantFieldsWithCurrFieldTag = allRelevantFields.filter(candField => field.tag === candField.tag);
+
+    if (relevantFieldsWithCurrFieldTag.length !== 1) {
+      nvdebug(` Number of them using tag ${field.tag} is ${relevantFieldsWithCurrFieldTag.length}. Can not disambiguate!`);
+      return false;
+    }
+
+    return true;
+  }
+
+  function disambiguateOccurrenceNumber(field) {
+    if (!disambiguateable(field)) {
+      return;
+    }
+    // Reset field:
+    const occurrenceNumber = fieldGetUnambiguousOccurrenceNumber(field);
+    const newOccurrenceNumberAsInt = recordGetMaxSubfield6OccurrenceNumberAsInteger(record) + 1;
+    const newOccurrenceNumber = intToOccurrenceNumberString(newOccurrenceNumberAsInt);
+    const pairedFields = fieldGetOccurrenceNumberPairs(field, record.fields);
+
+    nvdebug(` Reindex '${fieldToString(field)}' occurrence number and it's ${pairedFields.length} pair(s) using '${newOccurrenceNumber}'`, debug);
+
+    resetFieldOccurrenceNumber(field, newOccurrenceNumber, occurrenceNumber);
+    pairedFields.forEach(pairedField => resetFieldOccurrenceNumber(pairedField, newOccurrenceNumber, occurrenceNumber));
+
+  }
+
+
+}
+function recordGetNumberOfUniqueSubfield6OccurrenceNumbers(record) {
+  // Calculates the number of used different occurrence numbers
+  /* eslint-disable */
+  let indexArray = [];
+  record.fields.forEach(field => gatherFieldData(field));
+
+  function gatherFieldData(field) {
+    if (!field.subfields) {
+      return;
+    }
+    field.subfields.forEach(subfield => gatherSubfieldData(subfield));
+  }
+
+  function gatherSubfieldData(subfield) {
+    if (!isValidSubfield6(subfield)) {
+      return;
+    }
+    const i = subfield6GetOccurrenceNumberAsInteger(subfield);
+    if (i === 0) {
+      return
+    }
+    indexArray[i] = 1;
+  }
+  let n = 0;
+  indexArray.forEach(elem => n+= elem); 
+  /* eslint-enable */
+  return n;
+}
+
+export function recordResetSubfield6OccurrenceNumbers(record) { // Remove gaps
+  /* eslint-disable */
+  let currentInt = 1;
+  let oldtoNewCache = {};
+
+  record.fields.forEach(field => fieldResetSubfield6(field));
+
+  function fieldResetSubfield6(field) {
+    nvdebug(`fieldResetSubfield6(${fieldToString(field)}), CURR:${currentInt}`, debug);
+    if (!field.subfields) {
+      return;
+    }
+    field.subfields.forEach(subfield => subfieldReset6(subfield));
+  }
+
+  function subfieldReset6(subfield) {
+    if (!isValidSubfield6(subfield)) {
+      return;
+    }
+    const currIndex = subfield6GetOccurrenceNumber(subfield);
+    if (currIndex === undefined || currIndex === '00') {
+      return;
+    }
+
+    const newIndex = mapCurrIndexToNewIndex(currIndex);
+    //nvdebug(`subfieldReset6(${subfieldToString(subfield)}): ${newIndex}`, debug);
+    resetSubfield6OccurrenceNumber(subfield, newIndex);
+  }
+
+  function mapCurrIndexToNewIndex(currIndex) {
+    if(currIndex in oldtoNewCache) {
+      return oldtoNewCache[currIndex];
+    }
+    const newIndex = intToOccurrenceNumberString(currentInt);
+    oldtoNewCache[currIndex] = newIndex;
+    currentInt++;
+    return newIndex;
+  }
+
+  /* eslint-enable */
+
+}

--- a/src/reindexSubfield6OccurenceNumbers.spec.js
+++ b/src/reindexSubfield6OccurenceNumbers.spec.js
@@ -1,15 +1,15 @@
 import {expect} from 'chai';
 import {MarcRecord} from '@natlibfi/marc-record';
-import validatorFactory from './mergeField500Lisapainokset';
+import validatorFactory from './reindexSubfield6OccurenceNumbers';
 import {READERS} from '@natlibfi/fixura';
 import generateTests from '@natlibfi/fixugen';
 import createDebugLogger from 'debug';
 
 generateTests({
   callback,
-  path: [__dirname, '..', 'test-fixtures', 'lisapainokset'],
+  path: [__dirname, '..', 'test-fixtures', 'reindex-sf6-occurence-numbers'],
   useMetadataFile: true,
-  recurse: true,
+  recurse: false,
   fixura: {
     reader: READERS.JSON
   },
@@ -17,7 +17,7 @@ generateTests({
     before: () => testValidatorFactory()
   }
 });
-const debug = createDebugLogger('@natlibfi/marc-record-validators-melinda/mergeField500Lisapainokset:test');
+const debug = createDebugLogger('@natlibfi/marc-record-validators-melinda/reindexSubfield6OccurrenceNumbers:test');
 
 async function testValidatorFactory() {
   const validator = await validatorFactory();

--- a/src/removeDuplicateDataFields.js
+++ b/src/removeDuplicateDataFields.js
@@ -1,0 +1,284 @@
+import createDebugLogger from 'debug';
+import {fieldHasSubfield, fieldsToString, fieldToString, nvdebug} from './utils';
+import {fieldHasOccurrenceNumber, fieldsToNormalizedString, isValidSubfield6, subfield6GetOccurrenceNumber} from './subfield6Utils';
+import {getSubfield8LinkingNumber, recordGetAllSubfield8LinkingNumbers, recordGetFieldsWithSubfield8LinkingNumber} from './subfield8Utils';
+
+// Relocated from melinda-marc-record-merge-reducers (and renamed)
+
+const debug = createDebugLogger('@natlibfi/marc-record-validators-melinda:removeDuplicateDataFields');
+
+export default function () {
+  return {
+    description: 'Remove duplicate data fields. Certain exceptions apply, mainly too complited chained fields',
+    validate, fix
+  };
+
+  function fix(record) {
+    nvdebug('Remove duplicate data fields');
+    const res = {message: [], fix: [], valid: true};
+    removeDuplicateDatafields(record, true);
+    // This can not really fail...
+    return res;
+  }
+
+  function validate(record) {
+    // Check max, and check number of different indexes
+    nvdebug('Validate record: duplicate data fields cause (t)error', debug);
+
+    const duplicates = removeDuplicateDatafields(record, false);
+
+    //const orphanedFields = getOrphanedFields(fieldsContainingSubfield6);
+
+    const res = {message: duplicates};
+
+    /*
+    if (orphanedFields.length > 0) { // eslint-disable-line functional/no-conditional-statement
+      res.message = [`${orphanedFields.length} orphaned occurrence number field(s) detected`]; // eslint-disable-line functional/immutable-data
+    }
+    */
+    res.valid = res.message.length < 1; // eslint-disable-line functional/immutable-data
+    return res;
+  }
+}
+
+function add6s(field, record) {
+
+  /*
+  // Can't rely on nice pairs...
+  if (fieldHasSubfield(field, '6')) {
+
+    const pairs = fieldGetOccurrenceNumberPairs(field, record.fields);
+    if (pairs) {
+      return [field].concat(pairs);
+    }
+
+  }
+  */
+
+  // Get all fields with given occurence number
+  const sixes = field.subfields.filter(sf => isValidSubfield6(sf));
+
+  if (sixes.length === 0) {
+    return [field];
+  }
+  nvdebug(`SIXES: ${sixes.length}`);
+  const occurrenceNumbers = sixes.map(sf => subfield6GetOccurrenceNumber(sf)).filter(value => value !== undefined && value !== '00');
+  nvdebug(occurrenceNumbers.join(' -- '));
+
+  const relevantFields = record.fields.filter(f => occurrenceNumbers.some(o => fieldHasOccurrenceNumber(f, o)));
+  nvdebug(`RELFIELDS FOUND: ${relevantFields.length}...`);
+  relevantFields.forEach(f => nvdebug(fieldToString(f)));
+  return relevantFields;
+}
+
+function add8s(fields, record) {
+  // Not implemented yet:
+  if (fields && fields.some(f => fieldHasSubfield(f, '8'))) {
+    return [];
+  }
+  return record ? fields : fields;
+}
+
+function numberOfLinkageSubfields(field) {
+  const subfields = field.subfields.filter(sf => sf.code === '6' || sf.code === '8');
+  return subfields.length;
+}
+
+
+function getAllLinkedSubfield6Fields(field, record) {
+  const fields = add6s(field, record);
+  const moreFields = add8s(fields, record);
+
+  // Currently we don't handle fields with more than one $6 and/or $8 subfield.
+  if (moreFields.length === 0 || moreFields.some(f => numberOfLinkageSubfields(f) > 1)) {
+    return []; // Don't fix!
+  }
+  return moreFields;
+}
+
+function getFirstField(record, fields) {
+  const fieldsAsStrings = fields.map(field => fieldToString(field));
+  record.fields.forEach((field, i) => nvdebug(`${i}:\t${fieldToString(field)}`));
+  nvdebug(`INCOMING: ${fieldsAsStrings.join('\t')}`);
+  const i = record.fields.findIndex(field => fieldsAsStrings.includes(fieldToString(field)));
+  if (i > -1) {
+    const field = record.fields[i];
+    nvdebug(`1st F: ${i + 1}/${record.fields.length} ${fieldToString(field)}`);
+    return field;
+  }
+  return undefined;
+}
+
+
+function isFirstLinkedSubfield6Field(field, record) {
+  if (!field.subfields) { // Is not a datafield
+    return false;
+  }
+  const chain = getAllLinkedSubfield6Fields(field, record);
+  if (chain.length < 2) {
+    return false;
+  }
+
+  // Interpretation of first: position of field in record (however, we might have a duplicate field. See tests...)
+  const firstField = getFirstField(record, chain);
+  if (firstField) {
+    return fieldToString(field) === fieldToString(firstField);
+  }
+  return false;
+
+  // Fallback:
+  //return fieldToString(field) === fieldToString(chain[0]);
+}
+
+export function removeIndividualDuplicateDatafields(record, fix = true) { // No $6 nor $8 in field
+  /* eslint-disable */
+  let seen = {};
+
+  let removables = []; // for validation
+
+  //record.fields.forEach(field => nvdebug(`DUPL-1 CHECK SINGLE ${fieldToString(field)}, mode=${fix ? 'FIX' : 'VALIDATE'}`));
+  
+  const fields = record.fields;
+  
+  fields.forEach(field => removeIndividualDuplicateDatafield(field));
+
+  function removeIndividualDuplicateDatafield(field) {
+    //nvdebug(`removeIndividualDuplicateDatafield? ${fieldToString(field)} (and friends)`);
+
+    // We are in trouble if $9 ^ and $9 ^^ style chains appear here...
+    const fieldAsString = fieldToString(field); // Never normalize!
+
+    //nvdebug(` step 2 ${fieldAsString}`);
+    if (fieldAsString in seen)  {
+      // nvdebug(` step 3 ${fieldAsString}`);
+      // There's actually no reason to check whether individual fields contain a $6 or an $8...
+
+      if (!removables.includes(fieldAsString)) {
+        removables.push(fieldAsString);
+      }
+
+      if (fix) {
+        //nvdebug(`DOUBLE REMOVAL: REMOVE ${fieldAsString}`, debug);
+        fields.forEach(currField => record.removeField(currField));
+        return;
+      }
+      nvdebug(`VALIDATION-1: DUPLICATE DETECTED ${fieldAsString}`, debug);
+      return;
+    }
+    nvdebug(`ADD2SEEN-1 ${fieldAsString}`, debug);
+    seen[fieldAsString] = 1;
+    return;
+  }
+  /* eslint-enable */
+  return removables;
+}
+
+
+function recordRemoveFieldOrSubfield8(record, field, currLinkingNumber) {
+  const eights = field.subfields.filter(sf => sf.code === '8');
+  if (eights.length < 2) {
+    record.removeField(field);
+    return;
+  }
+  const subfields = field.subfields.filter(sf => getSubfield8LinkingNumber(sf) === currLinkingNumber);
+  subfields.forEach(sf => record.removeSubfield(sf, field));
+}
+
+
+export function removeDuplicateSubfield8Chains(record, fix = true) {
+  /* eslint-disable */
+  let seen = {};
+
+  let removables = []; // for validation
+
+  nvdebug("CHAIN-8");
+  const seenLinkingNumbers = recordGetAllSubfield8LinkingNumbers(record);
+  if (seenLinkingNumbers.length === 0) {
+    return removables;
+  }
+
+  nvdebug(`seen linking numbers ($8): ${seenLinkingNumbers.join(', ')}`, debug);
+
+  seenLinkingNumbers.forEach(currLinkingNumber => {
+    const linkedFields = recordGetFieldsWithSubfield8LinkingNumber(record, currLinkingNumber) //getFieldsWithSubfield8Index(base, baseIndex);
+    const linkedFieldsAsString = fieldsToNormalizedString(linkedFields, currLinkingNumber);
+    nvdebug(`Results for LINKING NUMBER ${currLinkingNumber}:`, debug);
+    nvdebug(`${linkedFieldsAsString}`, debug);
+
+    if (linkedFieldsAsString in seen)  {
+      if (!removables.includes(linkedFieldsAsString)) {
+        removables.push(linkedFieldsAsString);
+      }
+
+      if (fix) {
+        nvdebug(`$8 CHAIN FIX: REMOVE $8 GROUP: ${fieldsToString(linkedFields)}`, debug);
+        linkedFields.forEach(field => recordRemoveFieldOrSubfield8(record, field, currLinkingNumber));
+        return;
+      }
+
+      nvdebug(`$8 VALIDATION: DUPLICATE DETECTED ${linkedFieldsAsString}`, debug);
+      return;
+    }
+    nvdebug(`$8 DOUBLE REMOVAL OR VALIDATION: ADD2SEEN ${linkedFieldsAsString}`, debug);
+    seen[linkedFieldsAsString] = 1;
+    return;
+  });
+
+  /* eslint-enable */
+  return removables;
+}
+
+export function removeDuplicateSubfield6Chains(record, fix = true) {
+  /* eslint-disable */
+  let seen = {};
+
+  let removables = []; // for validation
+
+  record.fields.forEach(field => nvdebug(`DUPL-CHECK $CHAIN ${fieldToString(field)}, mode=${fix ? 'FIX' : 'VALIDATE'}`));
+  
+  const fields = record.fields.filter(field => isFirstLinkedSubfield6Field(field, record)); // Well a
+  
+  fields.forEach(field => removeDuplicateDatafield(field));
+
+  function removeDuplicateDatafield(field) {
+    nvdebug(`removeDuplicateDatafield? $6 ${fieldToString(field)} (and friends)`);
+    const fields = getAllLinkedSubfield6Fields(field, record);
+    if(fields.length === 0) {
+      return;
+    }
+
+    const fieldsAsString = fieldsToNormalizedString(fields);
+    nvdebug(` step 2 ${fieldsAsString}`);
+    if (fieldsAsString in seen)  {
+      nvdebug(` step 3 ${fieldsAsString}`);
+
+      removables.push(fieldsAsString);
+
+      if (fix) {
+        nvdebug(`DOUBLE REMOVAL: REMOVE ${fieldsAsString}`, debug);
+        fields.forEach(currField => record.removeField(currField));
+        return;
+      }
+      nvdebug(`VALIDATION: DUPLICATE DETECTED ${fieldsAsString}`, debug);
+      
+    }
+    nvdebug(`DOUBLE REMOVAL OR VALIDATION: ADD2SEEN ${fieldsAsString}`, debug);
+    seen[fieldsAsString] = 1;
+    return;
+  }
+
+
+  /* eslint-enable */
+  return removables;
+}
+
+export function removeDuplicateDatafields(record, fix = true) {
+  const removables = removeIndividualDuplicateDatafields(record, fix); // Lone fields
+  const removables8 = removeDuplicateSubfield8Chains(record, fix); // Lone subfield $8 chains
+  const removables6 = removeDuplicateSubfield6Chains(record, fix); // Lone subfield $6 chains
+  // HOW TO HANDLE $6+$8 combos?
+
+  const removablesAll = removables.concat(removables8).concat(removables6);
+
+  return removablesAll;
+}

--- a/src/removeDuplicateDataFields.spec.js
+++ b/src/removeDuplicateDataFields.spec.js
@@ -1,15 +1,15 @@
 import {expect} from 'chai';
 import {MarcRecord} from '@natlibfi/marc-record';
-import validatorFactory from './mergeField500Lisapainokset';
+import validatorFactory from './removeDuplicateDataFields';
 import {READERS} from '@natlibfi/fixura';
 import generateTests from '@natlibfi/fixugen';
 import createDebugLogger from 'debug';
 
 generateTests({
   callback,
-  path: [__dirname, '..', 'test-fixtures', 'lisapainokset'],
+  path: [__dirname, '..', 'test-fixtures', 'remove-duplicate-datafields'],
   useMetadataFile: true,
-  recurse: true,
+  recurse: false,
   fixura: {
     reader: READERS.JSON
   },
@@ -17,7 +17,7 @@ generateTests({
     before: () => testValidatorFactory()
   }
 });
-const debug = createDebugLogger('@natlibfi/marc-record-validators-melinda/mergeField500Lisapainokset:test');
+const debug = createDebugLogger('@natlibfi/marc-record-validators-melinda/removeDuplicateDataFields:test');
 
 async function testValidatorFactory() {
   const validator = await validatorFactory();

--- a/src/resolveOrphanedSubfield6s.js
+++ b/src/resolveOrphanedSubfield6s.js
@@ -1,0 +1,115 @@
+import createDebugLogger from 'debug';
+import {fieldHasSubfield, fieldToString, nvdebug, subfieldToString} from './utils';
+import {fieldHasWantedTagAndOccurrenceNumber, isValidSubfield6, resetSubfield6OccurrenceNumber, subfield6GetOccurrenceNumber} from './subfield6Utils';
+
+// Relocated from melinda-marc-record-merge-reducers (and renamed)
+
+const debug = createDebugLogger('@natlibfi/marc-record-validators-melinda:resolveOrphanedSubfield6s');
+
+export default function () {
+  return {
+    description: 'Remove occurrence-number-orphaned $6 subfields. In field 880, occurrence number becomes 00',
+    validate, fix
+  };
+
+  function fix(record) {
+    nvdebug('Fix SF6 orphaned occurrence numbers');
+    const res = {message: [], fix: [], valid: true};
+    //message.fix = []; // eslint-disable-line functional/immutable-data
+
+    // This can not really fail...
+    recordFixSubfield6OccurrenceNumbers(record);
+
+    //message.valid = !(message.message.length >= 1); // eslint-disable-line functional/immutable-data
+    return res;
+  }
+
+  function validate(record) {
+    // Check max, and check number of different indexes
+    nvdebug('Validate SF6 orphaned occurrence numbers', debug);
+    const fieldsContainingSubfield6 = record.fields.filter(field => fieldHasSubfield(field, '6'));
+
+    const orphanedFields = getOrphanedFields(fieldsContainingSubfield6);
+
+    const res = {message: []};
+
+    if (orphanedFields.length > 0) { // eslint-disable-line functional/no-conditional-statement
+      res.message = [`${orphanedFields.length} orphaned occurrence number field(s) detected`]; // eslint-disable-line functional/immutable-data
+    }
+    res.valid = res.message.length < 1; // eslint-disable-line functional/immutable-data
+    return res;
+  }
+}
+
+export function recordFixSubfield6OccurrenceNumbers(record) {
+  const fieldsContainingSubfield6 = record.fields.filter(field => fieldHasSubfield(field, '6'));
+  const orphanedFields = getOrphanedFields(fieldsContainingSubfield6);
+
+  orphanedFields.forEach(field => fieldFixOrphanedSubfields(field));
+
+  function fieldFixOrphanedSubfields(field) {
+    // Field 880: orphaned $6 subfields: occurrence number is changed to '00':
+    if (field.tag === '880') {
+      field.subfields.forEach(sf => field880FixOrphanedSubfield(sf));
+      return;
+    }
+    // Non-880 fields get their orphaned $6s removed:
+    const remainingSubfields = field.subfields.filter(sf => !isOrphanedSubfield(sf, field.tag, fieldsContainingSubfield6));
+    if (remainingSubfields.length === 0) {
+      record.removeField(field);
+      return;
+    }
+    field.subfields = remainingSubfields; // eslint-disable-line functional/immutable-data
+  }
+
+  function field880FixOrphanedSubfield(subfield) {
+    if (!isOrphanedSubfield(subfield, '880', fieldsContainingSubfield6)) {
+      return;
+    }
+    // convert occurrence number to 00
+    resetSubfield6OccurrenceNumber(subfield, '00');
+  }
+}
+
+
+function findPairForSubfield6OccurrenceNumber(subfield6, myTag, candPairFields) {
+  // We keep the crap!
+  if (!isValidSubfield6(subfield6)) {
+    return undefined;
+  }
+  nvdebug(`LOOKING FOR PAIR: ${myTag} ${subfieldToString(subfield6)}`);
+  candPairFields.forEach(field => fieldToString(field));
+
+  // Only valid $6 value that fails to map to another field is iffy...
+  const referredTag = subfield6.value.substring(0, 3);
+
+  const occurrenceNumber = subfield6GetOccurrenceNumber(subfield6);
+  if (occurrenceNumber === '00') {
+    return undefined;
+  }
+  const tagAndOccurrenceNumber = `${myTag}-${occurrenceNumber}`;
+  nvdebug(`Try to find occurrence number ${tagAndOccurrenceNumber} in field ${referredTag}...`);
+  //const relevantFields = fields.filter(field => field.tag === referredTag && field.subfields.some(sf => subfield6GetOccurrenceNumber(sf) === occurrenceNumber));
+  const relevantFields = candPairFields.filter(field => field.tag === referredTag && fieldHasWantedTagAndOccurrenceNumber(field, tagAndOccurrenceNumber));
+  if (relevantFields.length === 0) {
+    return undefined;
+  }
+  // This should always return just one (not sanity checking this for now):
+  return relevantFields[0];
+}
+
+function isOrphanedSubfield(subfield, tag, pairCandidateFields) {
+  if (!isValidSubfield6(subfield) || subfield6GetOccurrenceNumber(subfield) === '00') {
+    return false;
+  }
+  return !findPairForSubfield6OccurrenceNumber(subfield, tag, pairCandidateFields);
+}
+
+
+function isOrphanedField(field, candidatePairFields) {
+  return field.subfields.some(sf => isOrphanedSubfield(sf, field.tag, candidatePairFields));
+}
+
+function getOrphanedFields(relevantFields) {
+  return relevantFields.filter(field => isOrphanedField(field, relevantFields));
+}

--- a/src/resolveOrphanedSubfield6s.spec.js
+++ b/src/resolveOrphanedSubfield6s.spec.js
@@ -1,15 +1,15 @@
 import {expect} from 'chai';
 import {MarcRecord} from '@natlibfi/marc-record';
-import validatorFactory from './mergeField500Lisapainokset';
+import validatorFactory from './resolveOrphanedSubfield6s';
 import {READERS} from '@natlibfi/fixura';
 import generateTests from '@natlibfi/fixugen';
 import createDebugLogger from 'debug';
 
 generateTests({
   callback,
-  path: [__dirname, '..', 'test-fixtures', 'lisapainokset'],
+  path: [__dirname, '..', 'test-fixtures', 'remove-orphanded-sf6s'],
   useMetadataFile: true,
-  recurse: true,
+  recurse: false,
   fixura: {
     reader: READERS.JSON
   },
@@ -17,7 +17,7 @@ generateTests({
     before: () => testValidatorFactory()
   }
 });
-const debug = createDebugLogger('@natlibfi/marc-record-validators-melinda/mergeField500Lisapainokset:test');
+const debug = createDebugLogger('@natlibfi/marc-record-validators-melinda/resolveOrphanedSubfield6s:test');
 
 async function testValidatorFactory() {
   const validator = await validatorFactory();

--- a/src/subfield6Utils.js
+++ b/src/subfield6Utils.js
@@ -1,0 +1,369 @@
+// import createDebugLogger from 'debug';
+// const debug = createDebugLogger('@natlibfi/marc-record-validator-melinda/subfield6Utils');
+
+import {getSubfield8LinkingNumber, isValidSubfield8} from './subfield8Utils';
+import {fieldToString, nvdebug, subfieldToString} from './utils';
+
+// NB! Subfield 6 is non-repeatable and it should always comes first!
+// NB! Index size should always be 2 (preceding 0 required for 01..09) However, support for 100+ was added on 2023-02-27.
+// NB! Index value '00' are left as they are (is not paired/indexed/whatever.
+const sf6Regexp = /^[0-9][0-9][0-9]-(?:[0-9][0-9]|[1-9][0-9]+)(?:[^0-9].*)?$/u;
+
+export function isValidSubfield6(subfield) {
+  if (subfield.code !== '6') {
+    return false;
+  }
+  return subfield.value.match(sf6Regexp);
+}
+
+function subfield6GetTag(subfield) {
+  if (isValidSubfield6(subfield)) {
+    return subfield.value.substring(0, 3);
+  }
+  return undefined;
+}
+
+export function subfield6GetOccurrenceNumber(subfield) {
+  if (isValidSubfield6(subfield)) {
+    // Skip "TAG-" prefix. 2023-02-20: removed 2-digit requirement from here...
+    return subfield.value.substring(4).replace(/\D.*$/u, '');
+  }
+  return undefined;
+}
+
+export function subfield6GetOccurrenceNumberAsInteger(subfield) {
+  const index = subfield6GetOccurrenceNumber(subfield);
+  if (index === undefined || index === '00') {
+    return 0;
+  }
+  const result = parseInt(index, 10);
+  //nvdebug(`SF6: ${subfield.value} => ${index} => ${result}`, debug);
+  return result;
+}
+
+export function resetSubfield6OccurrenceNumber(subfield, occurrenceNumber) {
+  if (!isValidSubfield6(subfield)) {
+    return;
+  }
+  const occurrenceNumberAsString = typeof occurrenceNumber === 'number' ? intToOccurrenceNumberString(occurrenceNumber) : occurrenceNumber;
+
+  const newValue = subfield.value.substring(0, 4) + occurrenceNumberAsString + subfield6GetTail(subfield); // eslint-disable-line functional/immutable-data
+  //nvdebug(`Set subfield $6 value from ${subfieldToString(subfield)} to ${newValue}`);
+  subfield.value = newValue; // eslint-disable-line functional/immutable-data
+}
+
+
+function subfield6GetTail(subfield) {
+  if (isValidSubfield6(subfield)) {
+    // Skip "TAG-" prefix. 2023-02-20: removed 2-digit requirement from here...
+    return subfield.value.replace(/^\d+-\d+/u, '');
+  }
+  return '';
+}
+
+// <= SUBFIELD, FIELD =>
+
+/*
+export function fieldHasValidSubfield6AndIsNotAnAlternateGraphicRepresentation(field) {
+  // AlternateGraphicRepresentation is same as "field.tag === '880'""
+  if (!field.subfields || field.tag === '880') {
+    return false;
+  }
+  const sf6s = field.subfields.filter(sf => sf.code === '6' && sf.value.match(sf6Regexp));
+  return sf6s.length === 1;
+}
+*/
+
+export function fieldGetUnambiguousTag(field) {
+  const tags = field.subfields.filter(sf => subfield6GetTag(sf));
+  if (tags.length === 1) {
+    nvdebug(`   GOT ${tags.length} tag(s): ${subfieldToString(tags[0])}`);
+    return subfield6GetTag(tags[0]);
+  }
+  return undefined;
+}
+
+export function fieldGetUnambiguousOccurrenceNumber(field) {
+  const occurrenceNumbers = field.subfields.filter(sf => subfield6GetOccurrenceNumber(sf));
+  if (occurrenceNumbers.length === 1) {
+    return subfield6GetOccurrenceNumber(occurrenceNumbers[0]);
+  }
+  return undefined;
+}
+
+export function fieldHasOccurrenceNumber(field, occurrenceNumber) {
+  //nvdebug(`${occurrenceNumber} vs ${fieldToString(field)}`);
+  return field.subfields && field.subfields.some(sf => subfield6GetOccurrenceNumber(sf) === occurrenceNumber);
+}
+
+export function resetFieldOccurrenceNumber(field, newOccurrenceNumber, oldOccurrenceNumber = undefined) {
+  field.subfields.forEach(subfield => innerReset(subfield));
+
+  function innerReset(subfield) {
+    // (Optional) Check that this is really the occurrence number we wan't to reseot
+    if (oldOccurrenceNumber !== undefined) {
+      const currOccurrenceNumber = subfield6GetOccurrenceNumber(subfield);
+      if (currOccurrenceNumber !== oldOccurrenceNumber) {
+        return;
+      }
+    }
+    resetSubfield6OccurrenceNumber(subfield, newOccurrenceNumber);
+  }
+}
+
+export function intToOccurrenceNumberString(i) {
+  return i < 10 ? `0${i}` : `${i}`;
+}
+
+function fieldGetMaxSubfield6OccurrenceNumberAsInteger(field) {
+  //nvdebug(`Checking subfields $6 from ${JSON.stringify(field)}`);
+  const sf6s = field.subfields ? field.subfields.filter(subfield => isValidSubfield6(subfield)) : [];
+  if (sf6s.length === 0) {
+    return 0;
+  }
+  // There should always be one, but here we check every subfield.
+  //nvdebug(`Got ${field.subfields} $6-subfield(s) from ${JSON.stringify(field)}`, debug);
+  const vals = sf6s.map(sf => subfield6GetOccurrenceNumberAsInteger(sf));
+  return Math.max(...vals);
+}
+
+
+export function recordGetMaxSubfield6OccurrenceNumberAsInteger(record) {
+  // Should we cache the value here?
+  const vals = record.fields.map((field) => fieldGetMaxSubfield6OccurrenceNumberAsInteger(field));
+  return Math.max(...vals);
+}
+
+export function hasWantedTagAndOccurrenceNumber(subfield, tagAndOccurrenceNumber) {
+  if (subfield.code !== '6') {
+    return false;
+  }
+  // We could also use generic code and go getTag()+'-'+getIndex() instead of regexp...
+  const key = subfield.value.replace(/^([0-9][0-9][0-9]-[0-9][0-9]+).*$/u, '$1'); // eslint-disable-line prefer-named-capture-group
+  nvdebug(` Compare '${key}' vs '${tagAndOccurrenceNumber}'`);
+  return key === tagAndOccurrenceNumber;
+}
+
+
+export function fieldHasWantedTagAndOccurrenceNumber(field, tagAndOccurrenceNumber) {
+  return field.subfields && field.subfields.some(sf => hasWantedTagAndOccurrenceNumber(sf, tagAndOccurrenceNumber));
+}
+
+
+/*
+export function getFieldsWithGivenOccurrenceNumberSubfield6(record, occurrenceNumberAsString) {
+  const record.fields.filter(field => field
+
+  function fieldHasIndex(field, index) {
+    if (!field.subfields) {
+      return false;
+    }
+    return field.subfields.find(sf => isValidSubfield6(sf) && subfieldGetOccurrenceNumber6(sf) === index);
+  }
+}
+*/
+
+
+function fieldHasValidSubfield6(field) {
+  return field.subfields && field.subfields.some(sf => isValidSubfield6(sf));
+}
+
+
+/*
+
+export function subfieldGetOccurrenceNumber6(subfield) {
+  if (isValidSubfield6(subfield)) {
+    // Skip "TAG-" prefix. 2023-02-20: removed 2-digit requirement from here...
+    return subfield.value.substring(4).replace(/\D.*$/u, '');
+  }
+  return undefined;
+}
+
+function subfieldGetTag6(subfield) {
+  if (isValidSubfield6(subfield)) {
+    return subfield.value.substring(0, 3);
+  }
+  return undefined;
+}
+
+
+export function resetSubfield6Tag(subfield, tag) {
+  if (!isValidSubfield6(subfield)) {
+    return;
+  }
+  // NB! mainly for 1XX<->7XX transfers
+  const newValue = `${tag}-${subfield.value.substring(4)}`;
+  nvdebug(`Set subfield $6 value from ${subfieldToString(subfield)} to ${newValue}`);
+  subfield.value = newValue; // eslint-disable-line functional/immutable-data
+}
+
+
+*/
+
+
+/*
+export function fieldGetOccurrenceNumber6(field) {
+  if (!field.subfields) {
+    return undefined;
+  }
+  // Subfield $6 should always be the 1st subfield... (not implemented)
+  // There should be only one $6, so find is ok.
+  const sf6 = field.subfields.find(subfield => isValidSubfield6(subfield));
+  if (sf6 === undefined) {
+    return undefined;
+  }
+  return subfieldGetOccurrenceNumber6(sf6);
+}
+
+function fieldGetTag6(field) {
+  if (!field.subfields) {
+    return undefined;
+  }
+  // Subfield $6 should always be the 1st subfield... (not implemented)
+  // There should be only one $6, so find is ok.
+  const sf6 = field.subfields.find(subfield => isValidSubfield6(subfield));
+  if (sf6 === undefined) {
+    return undefined;
+  }
+  return subfieldGetTag6(sf6);
+}
+
+*/
+
+function isSubfield6Pair(field, otherField) {
+  // No need to log this:
+  //nvdebug(`LOOK for $6-pair:\n ${fieldToString(field)}\n ${fieldToString(otherField)}`);
+  if (!fieldHasValidSubfield6(field) || !fieldHasValidSubfield6(otherField)) {
+    return false;
+  }
+
+  if (!tagsArePairable6(field.tag, otherField.tag)) {
+    //nvdebug(` FAILED. REASON: TAGS NOT PAIRABLE!`);
+    return false;
+  }
+
+
+  const fieldIndex = fieldGetUnambiguousOccurrenceNumber(field);
+  if (fieldIndex === undefined || fieldIndex === '00') {
+    //nvdebug(` FAILED. REASON: NO INDEX FOUND`);
+    return false;
+  }
+
+  const otherFieldIndex = fieldGetUnambiguousOccurrenceNumber(otherField);
+
+
+  if (fieldIndex !== otherFieldIndex) {
+    //nvdebug(` FAILURE: INDEXES: ${fieldIndex} vs ${otherFieldIndex}`);
+    return false;
+  }
+
+  if (fieldGetUnambiguousTag(field) !== otherField.tag || field.tag !== fieldGetUnambiguousTag(otherField)) {
+    //nvdebug(` FAILURE: TAG vs $6 TAG`);
+    return false;
+  }
+  return true;
+
+  function tagsArePairable6(tag1, tag2) {
+    // How to do XOR operation in one line? Well, this is probably more readable...
+    if (tag1 === '880' && tag2 === '880') {
+      return false;
+    }
+    if (tag1 !== '880' && tag2 !== '880') {
+      return false;
+    }
+    return true;
+  }
+}
+
+export function fieldGetOccurrenceNumberPairs(field, candFields) {
+  // NB! TAG!=880 returns 880 fields, TAG==880 returns non-880 field
+  //nvdebug(`  Trying to finds pair for ${fieldToString(field)} in ${candFields.length} fields`);
+  const pairs = candFields.filter(otherField => isSubfield6Pair(field, otherField));
+  if (pairs.length === 0) {
+    nvdebug(`NO PAIRS FOUND FOR '${fieldToString(field)}'`);
+    return pairs;
+  }
+  nvdebug(`${pairs.length} PAIR(S) FOUND FOR '${fieldToString(field)}'`);
+  pairs.forEach(pairedField => nvdebug(`  '${fieldToString(pairedField)}'`));
+  return pairs;
+}
+
+/*
+export function fieldGetSubfield6Pair(field, record) {
+  const pairedFields = record.fields.filter(otherField => isSubfield6Pair(field, otherField));
+  if (pairedFields.length !== 1) {
+    return undefined;
+  }
+  // NB! It is theoretically possible to have multiple pairable 880 fields (one for each encoding)
+  nvdebug(`fieldGetSubfield6Pair(): ${fieldToString(field)} => ${fieldToString(pairedFields[0])}`);
+  return pairedFields[0];
+}
+*/
+
+/*
+export function pairAndStringify6(field, record) {
+  const pair6 = fieldGetSubfield6Pair(field, record);
+  if (!pair6) {
+    return fieldToNormalizedString(field);
+  }
+  return fieldsToNormalizedString([field, pair6]);
+}
+*/
+
+export function subfieldToNormalizedString(sf, targetLinkingNumber = 0) {
+  if (isValidSubfield6(sf) && targetLinkingNumber === 0) {
+    // If we are normalizing $8 stuff, don't normalize $6 occurrence number!
+    // Replace $6 occurrence number with XX:
+    return ` ‡${sf.code} ${sf.value.substring(0, 3)}-XX${subfield6GetTail(sf)}`;
+  }
+  if (isValidSubfield8(sf)) {
+    const currLinkingNumber = getSubfield8LinkingNumber(sf); //getSubfield8Index(sf);
+    if (targetLinkingNumber > 0 && currLinkingNumber === targetLinkingNumber) {
+      // For $8 we should only XX the index we are looking at...
+      const normVal = sf.value.replace(/^[0-9]+/u, 'XX');
+      return ` ‡${sf.code} ${normVal}`;
+    }
+    return ''; // Other $8 subfields are meaningless in this context
+  }
+  return ` ${subfieldToString(sf)}`; // `‡${sf.code} ${sf.value}`;
+}
+
+export function fieldToNormalizedString(field, targetLinkingNumber = 0) {
+  if ('subfields' in field) {
+    return `${field.tag} ${field.ind1}${field.ind2}${formatAndNormalizeSubfields(field)}`;
+  }
+  return `${field.tag}    ${field.value}`;
+
+  function formatAndNormalizeSubfields(field) {
+    return field.subfields.map(sf => subfieldToNormalizedString(sf, targetLinkingNumber)).join('');
+  }
+}
+
+export function fieldsToNormalizedString(fields, index = 0) {
+  const strings = fields.map(field => fieldToNormalizedString(field, index));
+  strings.sort(); // eslint-disable-line functional/immutable-data
+  return strings.join('\t__SEPARATOR__\t');
+}
+
+/*
+
+export function removeField6IfNeeded(field, record, fieldsAsString) {
+  const pairField = fieldGetSubfield6Pair(field, record);
+  const asString = pairField ? fieldsToNormalizedString([field, pairField]) : fieldToNormalizedString(field);
+  nvdebug(`SOURCE: ${asString} -- REALITY: ${fieldToString(field)}`);
+  const tmp = pairField ? fieldToString(pairField) : 'HUTI';
+  nvdebug(`PAIR: ${tmp}`);
+  nvdebug(`BASE:\n ${fieldsAsString.join('\n ')}`);
+  if (!fieldsAsString.includes(asString)) {
+    return;
+  }
+  nvdebug(`Duplicate $6 removal: ${fieldToString(field)}`);
+  record.removeField(field);
+
+  if (pairField === undefined) {
+    return;
+  }
+  nvdebug(`Duplicate $6 removal (pair): ${fieldToString(pairField)}`);
+  record.removeField(pairField);
+}
+*/

--- a/src/subfield8Utils.js
+++ b/src/subfield8Utils.js
@@ -1,0 +1,69 @@
+// import createDebugLogger from 'debug';
+// const debug = createDebugLogger('@natlibfi/marc-record-validator-melinda/subfield8Utils');
+
+import {nvdebug, subfieldToString} from './utils';
+
+const sf8Regexp = /^([1-9][0-9]*)(?:\.[0-9]+)?(?:\\[acprux])?$/u; // eslint-disable-line prefer-named-capture-group
+
+export function isValidSubfield8(subfield) {
+  if (subfield.code !== '8') {
+    return false;
+  }
+
+  nvdebug(`   IS VALID $8? '${subfieldToString(subfield)}'`);
+  const match = subfield.value.match(sf8Regexp);
+  //nvdebug(`   IS VALID $8? '${subfieldToString(subfield)}' vs ${match.length}}`);
+  return match && match.length > 0;
+}
+
+function getSubfield8Value(subfield) {
+  if (!isValidSubfield8(subfield)) {
+    return undefined;
+  }
+  return subfield.value;
+}
+
+export function getSubfield8LinkingNumber(subfield) {
+  const value = getSubfield8Value(subfield);
+  if (value === undefined) {
+    return 0;
+  }
+  return parseInt(value, 10);
+}
+
+
+export function recordGetFieldsWithSubfield8LinkingNumber(record, linkingNumber) {
+  if (linkingNumber < 1) {
+    return;
+  }
+  return record.fields.filter(field => relevant4GFWS8I(field));
+
+  function relevant4GFWS8I(field) {
+    if (!field.subfields) {
+      return false;
+    }
+    return field.subfields.some(sf => getSubfield8LinkingNumber(sf) === linkingNumber);
+  }
+}
+
+
+export function recordGetAllSubfield8LinkingNumbers(record) {
+  /* eslint-disable */
+  let subfield8LinkingNumbers = [];
+  record.fields.forEach(field => {
+    if (!field.subfields) {
+      return;
+    }
+    field.subfields.forEach(sf => {
+      const linkingNumber = getSubfield8LinkingNumber(sf);
+      nvdebug(`WP50: ${linkingNumber} vs '${subfieldToString(sf)}`);
+      if (linkingNumber > 0 && !subfield8LinkingNumbers.includes(linkingNumber)) {
+        nvdebug(` LINK8: Add subfield \$8 ${linkingNumber} to seen values list`);
+        subfield8LinkingNumbers.push(linkingNumber);
+      }
+    });
+  });
+
+  return subfield8LinkingNumbers;
+  /* eslint-enable */
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,3 +7,40 @@ export function isElectronicMaterial(record) {
     return mediaTypeIsC && sourceIsRdamedia;
   });
 }
+
+export function nvdebug(message, func = undefined) {
+  if (func) { // eslint-disable-line functional/no-conditional-statement
+    func(message);
+  }
+  //console.info(message); // eslint-disable-line no-console
+}
+
+export function fieldHasSubfield(field, subfieldCode, subfieldValue = null) {
+  if (!field.subfields) {
+    return false;
+  }
+  if (subfieldValue === null) {
+    return field.subfields.some(sf => sf.code === subfieldCode);
+  }
+  return field.subfields.some(sf => sf.code === subfieldCode && subfieldValue === sf.value);
+}
+
+export function subfieldToString(sf) {
+  return `‡${sf.code} ${sf.value}`;
+}
+
+export function fieldToString(f) {
+  if ('subfields' in f) {
+    return `${f.tag} ${f.ind1}${f.ind2}${formatSubfields(f)}`;
+  }
+  return `${f.tag}    ${f.value}`;
+
+  function formatSubfields(field) {
+    return field.subfields.map(sf => ` ${subfieldToString(sf)}`).join('');
+  }
+}
+
+export function fieldsToString(fields) {
+  return fields.map(f => fieldToString(f)).join('\t__SEPARATOR__\t');
+}
+

--- a/test-fixtures/reindex-sf6-occurence-numbers/f01/expectedResult.json
+++ b/test-fixtures/reindex-sf6-occurence-numbers/f01/expectedResult.json
@@ -1,0 +1,35 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01" },
+      { "code": "a", "value": "Zabara, Olena,"},
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "600", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-02" },
+      { "code": "a", "value": "FOO"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "653", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "term"} ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "500-00/(N" },
+      { "code": "a", "value": "Lorum ipsum." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "100-01/(N" },
+      { "code": "a", "value": "Забара, Олена," },
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "700-02" },
+      { "code": "a", "value": "BAR"},
+      { "code": "e", "value": "whatever" }
+    ]}
+
+  ],
+  "leader": ""
+}

--- a/test-fixtures/reindex-sf6-occurence-numbers/f01/metadata.json
+++ b/test-fixtures/reindex-sf6-occurence-numbers/f01/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "F01: no changes. Contains only 01...NN occurence numbers.",
+  "enabled": true,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/reindex-sf6-occurence-numbers/f01/record.json
+++ b/test-fixtures/reindex-sf6-occurence-numbers/f01/record.json
@@ -1,0 +1,34 @@
+{
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01" },
+      { "code": "a", "value": "Zabara, Olena,"},
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "600", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-02" },
+      { "code": "a", "value": "FOO"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "653", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "term"} ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "500-00/(N" },
+      { "code": "a", "value": "Lorum ipsum." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "100-01/(N" },
+      { "code": "a", "value": "Забара, Олена," },
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "700-02" },
+      { "code": "a", "value": "BAR"},
+      { "code": "e", "value": "whatever" }
+    ]}
+
+  ],
+  "leader": ""
+}

--- a/test-fixtures/reindex-sf6-occurence-numbers/f02/expectedResult.json
+++ b/test-fixtures/reindex-sf6-occurence-numbers/f02/expectedResult.json
@@ -1,0 +1,53 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01" },
+      { "code": "a", "value": "Zabara, Olena,"},
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "600", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-02" },
+      { "code": "a", "value": "FOO"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-03" },
+      { "code": "a", "value": "Pairless"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "800", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-04" },
+      { "code": "a", "value": "Paired #2"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "500-00/(N" },
+      { "code": "a", "value": "Lorum ipsum." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "100-01/(N" },
+      { "code": "a", "value": "Забара, Олена," },
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "700-02" },
+      { "code": "a", "value": "BAR"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "700-05" },
+      { "code": "a", "value": "Pairless #2"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "800-04" },
+      { "code": "a", "value": "Paired #2"},
+      { "code": "e", "value": "whatever" }
+    ]}
+
+  ],
+  "leader": ""
+}

--- a/test-fixtures/reindex-sf6-occurence-numbers/f02/metadata.json
+++ b/test-fixtures/reindex-sf6-occurence-numbers/f02/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "F02: $6 has gaps in occurrence numbers",
+  "enabled": true,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/reindex-sf6-occurence-numbers/f02/record.json
+++ b/test-fixtures/reindex-sf6-occurence-numbers/f02/record.json
@@ -1,0 +1,51 @@
+{
+  "fields": [
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-03" },
+      { "code": "a", "value": "Zabara, Olena,"},
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "600", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-04" },
+      { "code": "a", "value": "FOO"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-05" },
+      { "code": "a", "value": "Pairless"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "800", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-105" },
+      { "code": "a", "value": "Paired #2"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "500-00/(N" },
+      { "code": "a", "value": "Lorum ipsum." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "100-03/(N" },
+      { "code": "a", "value": "Забара, Олена," },
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "700-04" },
+      { "code": "a", "value": "BAR"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "700-06" },
+      { "code": "a", "value": "Pairless #2"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "800-105" },
+      { "code": "a", "value": "Paired #2"},
+      { "code": "e", "value": "whatever" }
+    ]}
+
+  ]
+}

--- a/test-fixtures/reindex-sf6-occurence-numbers/f03/expectedResult.json
+++ b/test-fixtures/reindex-sf6-occurence-numbers/f03/expectedResult.json
@@ -1,0 +1,46 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01" },
+      { "code": "a", "value": "Zabara, Olena,"},
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "600", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-02" },
+      { "code": "a", "value": "FOO"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "710", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-03" },
+      { "code": "a", "value": "NOISE."}
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "500-00/(N" },
+      { "code": "a", "value": "Lorum ipsum." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "100-01/(N" },
+      { "code": "a", "value": "Забара, Олена," },
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "600-02" },
+      { "code": "a", "value": "BAR"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "600-02" },
+      { "code": "a", "value": "BAR IN ANOTHER SCRIPT"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "700-03" },
+      { "code": "a", "value": "Sukunimi, Etunimi"},
+      { "code": "e", "value": "whatever" }
+    ]}
+  ],
+  "leader": ""
+}

--- a/test-fixtures/reindex-sf6-occurence-numbers/f03/metadata.json
+++ b/test-fixtures/reindex-sf6-occurence-numbers/f03/metadata.json
@@ -1,0 +1,7 @@
+{
+  "description": "Validate-03: $6 has shared occurrence numbers",
+  "comment": "880 $6 700-01 is not handled on purpose (which might appear strange). It is fixed by handle-orphaned-sf6s",
+  "enabled": true,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/reindex-sf6-occurence-numbers/f03/record.json
+++ b/test-fixtures/reindex-sf6-occurence-numbers/f03/record.json
@@ -1,0 +1,44 @@
+{
+  "fields": [
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01" },
+      { "code": "a", "value": "Zabara, Olena,"},
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "600", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01" },
+      { "code": "a", "value": "FOO"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "710", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01" },
+      { "code": "a", "value": "NOISE."}
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "500-00/(N" },
+      { "code": "a", "value": "Lorum ipsum." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "100-01/(N" },
+      { "code": "a", "value": "Забара, Олена," },
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "600-01" },
+      { "code": "a", "value": "BAR"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "600-01" },
+      { "code": "a", "value": "BAR IN ANOTHER SCRIPT"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "700-01" },
+      { "code": "a", "value": "Sukunimi, Etunimi"},
+      { "code": "e", "value": "whatever" }
+    ]}
+  ]
+}

--- a/test-fixtures/reindex-sf6-occurence-numbers/v01/expectedResult.json
+++ b/test-fixtures/reindex-sf6-occurence-numbers/v01/expectedResult.json
@@ -1,0 +1,6 @@
+{
+  "message": [
+
+  ],
+  "valid": true
+}

--- a/test-fixtures/reindex-sf6-occurence-numbers/v01/metadata.json
+++ b/test-fixtures/reindex-sf6-occurence-numbers/v01/metadata.json
@@ -1,0 +1,5 @@
+{
+  "description": "01: valid $6s",
+  "enabled": true,
+  "fix": false
+}

--- a/test-fixtures/reindex-sf6-occurence-numbers/v01/record.json
+++ b/test-fixtures/reindex-sf6-occurence-numbers/v01/record.json
@@ -1,0 +1,31 @@
+{
+  "fields": [
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01" },
+      { "code": "a", "value": "Zabara, Olena,"},
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "600", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-02" },
+      { "code": "a", "value": "FOO"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "500-00/(N" },
+      { "code": "a", "value": "Lorum ipsum." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "100-01/(N" },
+      { "code": "a", "value": "Забара, Олена," },
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "700-02" },
+      { "code": "a", "value": "BAR"},
+      { "code": "e", "value": "whatever" }
+    ]}
+
+  ]
+}

--- a/test-fixtures/reindex-sf6-occurence-numbers/v02/expectedResult.json
+++ b/test-fixtures/reindex-sf6-occurence-numbers/v02/expectedResult.json
@@ -1,0 +1,6 @@
+{
+  "message": [
+    "Gaps detected in occurrence numbers: found 4, seen max 666"
+  ],
+  "valid": false
+}

--- a/test-fixtures/reindex-sf6-occurence-numbers/v02/metadata.json
+++ b/test-fixtures/reindex-sf6-occurence-numbers/v02/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "Validate-02: $6 has gaps in occurrence numbers",
+  "enabled": true,
+  "fix": false,
+  "only": false
+}

--- a/test-fixtures/reindex-sf6-occurence-numbers/v02/record.json
+++ b/test-fixtures/reindex-sf6-occurence-numbers/v02/record.json
@@ -1,0 +1,38 @@
+{
+  "fields": [
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-03" },
+      { "code": "a", "value": "Zabara, Olena,"},
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "600", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-04" },
+      { "code": "a", "value": "FOO"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "800", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-104" }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "500-00/(N" },
+      { "code": "a", "value": "Lorum ipsum." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "100-03/(N" },
+      { "code": "a", "value": "Забара, Олена," },
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "700-04" },
+      { "code": "a", "value": "BAR"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "810-666" },
+      { "code": "a", "value": "Tässä kentässä hudin esiintymänumero muuttuu 00:ksi"}
+    ]}
+
+  ]
+}

--- a/test-fixtures/reindex-sf6-occurence-numbers/v03/expectedResult.json
+++ b/test-fixtures/reindex-sf6-occurence-numbers/v03/expectedResult.json
@@ -1,0 +1,6 @@
+{
+  "message": [
+    "Multi-use of occurrence number(s) detected"
+  ],
+  "valid": false
+}

--- a/test-fixtures/reindex-sf6-occurence-numbers/v03/metadata.json
+++ b/test-fixtures/reindex-sf6-occurence-numbers/v03/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "Validate-03: $6 has shared occurrence numbers",
+  "enabled": true,
+  "fix": false,
+  "only": false
+}

--- a/test-fixtures/reindex-sf6-occurence-numbers/v03/record.json
+++ b/test-fixtures/reindex-sf6-occurence-numbers/v03/record.json
@@ -1,0 +1,30 @@
+{
+  "fields": [
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01" },
+      { "code": "a", "value": "Zabara, Olena,"},
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "600", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01" },
+      { "code": "a", "value": "FOO"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "500-00/(N" },
+      { "code": "a", "value": "Lorum ipsum." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "100-01/(N" },
+      { "code": "a", "value": "Забара, Олена," },
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "600-01" },
+      { "code": "a", "value": "BAR"},
+      { "code": "e", "value": "whatever" }
+    ]}
+  ]
+}

--- a/test-fixtures/remove-duplicate-datafields/f01/expectedResult.json
+++ b/test-fixtures/remove-duplicate-datafields/f01/expectedResult.json
@@ -1,0 +1,35 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01" },
+      { "code": "a", "value": "Zabara, Olena,"},
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "600", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-02" },
+      { "code": "a", "value": "FOO"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "653", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "term"} ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "500-00/(N" },
+      { "code": "a", "value": "Lorum ipsum." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "100-01/(N" },
+      { "code": "a", "value": "Забара, Олена," },
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "600-02" },
+      { "code": "a", "value": "BAR"},
+      { "code": "e", "value": "whatever" }
+    ]}
+
+  ],
+  "leader": ""
+}

--- a/test-fixtures/remove-duplicate-datafields/f01/metadata.json
+++ b/test-fixtures/remove-duplicate-datafields/f01/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "f01: no removable occurrence numbers to fix",
+  "enabled": true,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/remove-duplicate-datafields/f01/record.json
+++ b/test-fixtures/remove-duplicate-datafields/f01/record.json
@@ -1,0 +1,34 @@
+{
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01" },
+      { "code": "a", "value": "Zabara, Olena,"},
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "600", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-02" },
+      { "code": "a", "value": "FOO"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "653", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "term"} ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "500-00/(N" },
+      { "code": "a", "value": "Lorum ipsum." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "100-01/(N" },
+      { "code": "a", "value": "Забара, Олена," },
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "600-02" },
+      { "code": "a", "value": "BAR"},
+      { "code": "e", "value": "whatever" }
+    ]}
+
+  ],
+  "leader": ""
+}

--- a/test-fixtures/remove-duplicate-datafields/f04/expectedResult.json
+++ b/test-fixtures/remove-duplicate-datafields/f04/expectedResult.json
@@ -1,0 +1,31 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "8", "value": "1.1\\x" },
+      { "code": "a", "value": "eka"}
+    ]},
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "8", "value": "1.2\\x" },
+      { "code": "a", "value": "toka"}
+    ]},
+
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "8", "value": "1.3\\x" },
+      { "code": "a", "value": "kolmas"}
+    ]},
+
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "8", "value": "3.1\\x" },
+      { "code": "a", "value": "eka"}
+    ]},
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "8", "value": "3.2\\x" },
+      { "code": "a", "value": "toka"}
+    ]}
+
+
+
+  ],
+  "leader": ""
+}

--- a/test-fixtures/remove-duplicate-datafields/f04/metadata.json
+++ b/test-fixtures/remove-duplicate-datafields/f04/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "Fix-04: remove duplicate $8 chain",
+  "enabled": true,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/remove-duplicate-datafields/f04/record.json
+++ b/test-fixtures/remove-duplicate-datafields/f04/record.json
@@ -1,0 +1,41 @@
+{
+  "fields": [
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "8", "value": "1.1\\x" },
+      { "code": "a", "value": "eka"}
+    ]},
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "8", "value": "1.2\\x" },
+      { "code": "a", "value": "toka"}
+    ]},
+
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "8", "value": "1.3\\x" },
+      { "code": "a", "value": "kolmas"}
+    ]},
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "8", "value": "2.1\\x" },
+      { "code": "a", "value": "eka"}
+    ]},
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "8", "value": "2.2\\x" },
+      { "code": "a", "value": "toka"}
+    ]},
+
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "8", "value": "2.3\\x" },
+      { "code": "a", "value": "kolmas"}
+    ]},
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "8", "value": "3.1\\x" },
+      { "code": "a", "value": "eka"}
+    ]},
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "8", "value": "3.2\\x" },
+      { "code": "a", "value": "toka"}
+    ]}
+
+
+
+  ]
+}

--- a/test-fixtures/remove-duplicate-datafields/f05/expectedResult.json
+++ b/test-fixtures/remove-duplicate-datafields/f05/expectedResult.json
@@ -1,0 +1,23 @@
+{  "_validationOptions": {},
+  "fields": [
+    { "tag": "650", "ind1": " ", "ind2": "4", "subfields": [
+      { "code": "8", "value": "1\\u" },
+      { "code": "8", "value": "3\\u" },
+      { "code": "a", "value": "eka"}
+    ]},
+    { "tag": "650", "ind1": " ", "ind2": "4", "subfields": [
+      { "code": "8", "value": "1\\u" },
+      { "code": "8", "value": "3\\u" },
+      { "code": "a", "value": "toka"}
+    ]},
+    { "tag": "650", "ind1": " ", "ind2": "4", "subfields": [
+      { "code": "8", "value": "1\\u" },
+      { "code": "a", "value": "kolmas"}
+    ]},
+    { "tag": "650", "ind1": " ", "ind2": "4", "subfields": [
+      { "code": "8", "value": "1\\u" },
+      { "code": "a", "value": "neljäs"}
+    ]}
+  ],
+  "leader": ""
+}

--- a/test-fixtures/remove-duplicate-datafields/f05/metadata.json
+++ b/test-fixtures/remove-duplicate-datafields/f05/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "Fix-05: remove duplicate $8 chain, some fields and some subfields",
+  "enabled": true,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/remove-duplicate-datafields/f05/record.json
+++ b/test-fixtures/remove-duplicate-datafields/f05/record.json
@@ -1,0 +1,29 @@
+{
+  "fields": [
+    { "tag": "650", "ind1": " ", "ind2": "4", "subfields": [
+      { "code": "8", "value": "1\\u" },
+      { "code": "8", "value": "2\\u" },
+      { "code": "8", "value": "3\\u" },
+      { "code": "a", "value": "eka"}
+    ]},
+    { "tag": "650", "ind1": " ", "ind2": "4", "subfields": [
+      { "code": "8", "value": "1\\u" },
+      { "code": "8", "value": "2\\u" },
+      { "code": "8", "value": "3\\u" },
+      { "code": "a", "value": "toka"}
+    ]},
+    { "tag": "650", "ind1": " ", "ind2": "4", "subfields": [
+      { "code": "8", "value": "1\\u" },
+      { "code": "8", "value": "2\\u" },
+      { "code": "a", "value": "kolmas"}
+    ]},
+    { "tag": "650", "ind1": " ", "ind2": "4", "subfields": [
+      { "code": "8", "value": "1\\u" },
+      { "code": "a", "value": "neljäs"}
+    ]},
+    { "tag": "650", "ind1": " ", "ind2": "4", "subfields": [
+      { "code": "8", "value": "2\\u" },
+      { "code": "a", "value": "neljäs"}
+    ]}
+  ]
+}

--- a/test-fixtures/remove-duplicate-datafields/f06/expectedResult.json
+++ b/test-fixtures/remove-duplicate-datafields/f06/expectedResult.json
@@ -1,0 +1,42 @@
+{ "_validationOptions": {},
+  "fields": [
+    { "tag": "245", "ind1": " ", "ind2": " ", "subfields": [  { "code": "a", "value": "TOO HARD TO FIX?" } ]},
+
+    { "tag": "520", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01" },
+      { "code": "a", "value": "Abstrakti. Blah Blah..." }
+    ]},
+    { "tag": "520", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-02" },
+      { "code": "a", "value": "Abstrakti. Blah Blah..." }
+    ]},
+    { "tag": "880", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "6", "value": "520-01" },
+      { "code": "8", "value": "1.1\\x" },
+      { "code": "a", "value": "Abstract, page1..."}
+    ]},
+    { "tag": "880", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "8", "value": "1.2\\x" },
+      { "code": "a", "value": "... continued, page2..."}
+    ]},
+    { "tag": "880", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "8", "value": "1.3\\x" },
+      { "code": "a", "value": "... page3, the end"}
+    ]},
+    
+    { "tag": "880", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "6", "value": "520-02" },
+      { "code": "8", "value": "2.1\\x" },
+      { "code": "a", "value": "Abstract, page1..."}
+    ]},
+    { "tag": "880", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "8", "value": "2.2\\x" },
+      { "code": "a", "value": "... continued, page2..."}
+    ]},
+    { "tag": "880", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "8", "value": "2.3\\x" },
+      { "code": "a", "value": "... page3, the end"}
+    ]}
+  ],
+  "leader": ""
+}

--- a/test-fixtures/remove-duplicate-datafields/f06/metadata.json
+++ b/test-fixtures/remove-duplicate-datafields/f06/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "Fix-06: record contains duplicate in a $6+$8 chain which so complicated to fix, that it is not yet supported",
+  "enabled": true,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/remove-duplicate-datafields/f06/record.json
+++ b/test-fixtures/remove-duplicate-datafields/f06/record.json
@@ -1,0 +1,41 @@
+{
+  "fields": [
+    { "tag": "245", "ind1": " ", "ind2": " ", "subfields": [  { "code": "a", "value": "TOO HARD TO FIX?" } ]},
+
+    { "tag": "520", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01" },
+      { "code": "a", "value": "Abstrakti. Blah Blah..." }
+    ]},
+    { "tag": "520", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-02" },
+      { "code": "a", "value": "Abstrakti. Blah Blah..." }
+    ]},
+    { "tag": "880", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "6", "value": "520-01" },
+      { "code": "8", "value": "1.1\\x" },
+      { "code": "a", "value": "Abstract, page1..."}
+    ]},
+    { "tag": "880", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "8", "value": "1.2\\x" },
+      { "code": "a", "value": "... continued, page2..."}
+    ]},
+    { "tag": "880", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "8", "value": "1.3\\x" },
+      { "code": "a", "value": "... page3, the end"}
+    ]},
+    
+    { "tag": "880", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "6", "value": "520-02" },
+      { "code": "8", "value": "2.1\\x" },
+      { "code": "a", "value": "Abstract, page1..."}
+    ]},
+    { "tag": "880", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "8", "value": "2.2\\x" },
+      { "code": "a", "value": "... continued, page2..."}
+    ]},
+    { "tag": "880", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "8", "value": "2.3\\x" },
+      { "code": "a", "value": "... page3, the end"}
+    ]}
+  ]
+}

--- a/test-fixtures/remove-duplicate-datafields/v01/expectedResult.json
+++ b/test-fixtures/remove-duplicate-datafields/v01/expectedResult.json
@@ -1,0 +1,6 @@
+{
+  "message": [
+
+  ],
+  "valid": true
+}

--- a/test-fixtures/remove-duplicate-datafields/v01/metadata.json
+++ b/test-fixtures/remove-duplicate-datafields/v01/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "v01: no deletable fields detected",
+  "enabled": true,
+  "fix": false,
+  "only": false
+}

--- a/test-fixtures/remove-duplicate-datafields/v01/record.json
+++ b/test-fixtures/remove-duplicate-datafields/v01/record.json
@@ -1,0 +1,31 @@
+{
+  "fields": [
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01" },
+      { "code": "a", "value": "Zabara, Olena,"},
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "600", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-02" },
+      { "code": "a", "value": "FOO"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "500-00/(N" },
+      { "code": "a", "value": "Lorum ipsum." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "100-01/(N" },
+      { "code": "a", "value": "Забара, Олена," },
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "600-02" },
+      { "code": "a", "value": "BAR"},
+      { "code": "e", "value": "whatever" }
+    ]}
+
+  ]
+}

--- a/test-fixtures/remove-duplicate-datafields/v02/expectedResult.json
+++ b/test-fixtures/remove-duplicate-datafields/v02/expectedResult.json
@@ -1,0 +1,11 @@
+{
+  "message": [
+    "500    ‡a Whatever.",
+    "700 1  ‡a B., B., ‡e kirjoittaja.",
+    "700 1  ‡6 880-01 ‡a C., C., ‡e kirjoittaja.",
+    "880 1  ‡6 700-02 ‡a D., D., ‡e kirjoittaja.",
+    "700 1  ‡6 880-XX ‡a C., C., ‡e kirjoittaja.\t__SEPARATOR__\t700 1  ‡6 880-XX ‡a C., C., ‡e kirjoittaja.",
+    "880 1  ‡6 700-XX ‡a D., D., ‡e kirjoittaja.\t__SEPARATOR__\t880 1  ‡6 700-XX ‡a D., D., ‡e kirjoittaja."
+  ],
+  "valid": false
+}

--- a/test-fixtures/remove-duplicate-datafields/v02/metadata.json
+++ b/test-fixtures/remove-duplicate-datafields/v02/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "Val-02: has identical normal fields",
+  "enabled": true,
+  "fix": false,
+  "only": false
+}

--- a/test-fixtures/remove-duplicate-datafields/v02/record.json
+++ b/test-fixtures/remove-duplicate-datafields/v02/record.json
@@ -1,0 +1,45 @@
+{
+  "fields": [
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "A., A.,"},
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "500", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "Whatever."} ]},
+    { "tag": "500", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "Whatever NOT."} ]},
+    { "tag": "500", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "Whatever."} ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "A., A.,"},
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "B., B.,"},
+      { "code": "e", "value": "kirjoittaja." }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "B., B.,"},
+      { "code": "e", "value": "kirjoittaja." }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01"},
+      { "code": "a", "value": "C., C.,"},
+      { "code": "e", "value": "kirjoittaja." }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01"},
+      { "code": "a", "value": "C., C.,"},
+      { "code": "e", "value": "kirjoittaja." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "700-02"},
+      { "code": "a", "value": "D., D.,"},
+      { "code": "e", "value": "kirjoittaja." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "700-02"},
+      { "code": "a", "value": "D., D.,"},
+      { "code": "e", "value": "kirjoittaja." }
+    ]}
+  ]
+}

--- a/test-fixtures/remove-duplicate-datafields/v03/expectedResult.json
+++ b/test-fixtures/remove-duplicate-datafields/v03/expectedResult.json
@@ -1,0 +1,7 @@
+{
+  "message": [
+    "100 1  ‡6 880-01 ‡a Zabara, Olena, ‡e kirjoittaja, ‡e taiteilija.",
+    "100 1  ‡6 880-XX ‡a Zabara, Olena, ‡e kirjoittaja, ‡e taiteilija.\t__SEPARATOR__\t100 1  ‡6 880-XX ‡a Zabara, Olena, ‡e kirjoittaja, ‡e taiteilija.\t__SEPARATOR__\t880 1  ‡6 100-XX/(N ‡a Забара, Олена, ‡e kirjoittaja, ‡e taiteilija."
+  ],
+  "valid": false
+}

--- a/test-fixtures/remove-duplicate-datafields/v03/metadata.json
+++ b/test-fixtures/remove-duplicate-datafields/v03/metadata.json
@@ -1,0 +1,7 @@
+{
+  "description": "Val-03: has only paired $6 occurrence numbers ",
+  "comment": "expected result has two failed rows, the second one is a bug, and it won't happen when the first issue is fixed",
+  "enabled": true,
+  "fix": false,
+  "only": false
+}

--- a/test-fixtures/remove-duplicate-datafields/v03/record.json
+++ b/test-fixtures/remove-duplicate-datafields/v03/record.json
@@ -1,0 +1,37 @@
+{
+  "fields": [
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01" },
+      { "code": "a", "value": "Zabara, Olena,"},
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01" },
+      { "code": "a", "value": "Zabara, Olena,"},
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "600", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-02" },
+      { "code": "a", "value": "FOO"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "500-00/(N" },
+      { "code": "a", "value": "Lorum ipsum." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "100-01/(N" },
+      { "code": "a", "value": "Забара, Олена," },
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "600-02" },
+      { "code": "a", "value": "BAR"},
+      { "code": "e", "value": "whatever" }
+    ]}
+
+  ]
+}

--- a/test-fixtures/remove-duplicate-datafields/v04/expectedResult.json
+++ b/test-fixtures/remove-duplicate-datafields/v04/expectedResult.json
@@ -1,0 +1,6 @@
+{
+  "message": [
+    "520 3  ‡8 XX.1\\x ‡a eka\t__SEPARATOR__\t520 3  ‡8 XX.2\\x ‡a toka\t__SEPARATOR__\t520 3  ‡8 XX.3\\x ‡a kolmas"
+  ],
+  "valid": false
+}

--- a/test-fixtures/remove-duplicate-datafields/v04/metadata.json
+++ b/test-fixtures/remove-duplicate-datafields/v04/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "Val-04: has duplicate $8 chain",
+  "enabled": true,
+  "fix": false,
+  "only": false
+}

--- a/test-fixtures/remove-duplicate-datafields/v04/record.json
+++ b/test-fixtures/remove-duplicate-datafields/v04/record.json
@@ -1,0 +1,41 @@
+{
+  "fields": [
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "8", "value": "1.1\\x" },
+      { "code": "a", "value": "eka"}
+    ]},
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "8", "value": "1.2\\x" },
+      { "code": "a", "value": "toka"}
+    ]},
+
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "8", "value": "1.3\\x" },
+      { "code": "a", "value": "kolmas"}
+    ]},
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "8", "value": "2.1\\x" },
+      { "code": "a", "value": "eka"}
+    ]},
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "8", "value": "2.2\\x" },
+      { "code": "a", "value": "toka"}
+    ]},
+
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "8", "value": "2.3\\x" },
+      { "code": "a", "value": "kolmas"}
+    ]},
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "8", "value": "3.1\\x" },
+      { "code": "a", "value": "eka"}
+    ]},
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "8", "value": "3.2\\x" },
+      { "code": "a", "value": "toka"}
+    ]}
+
+
+
+  ]
+}

--- a/test-fixtures/remove-orphanded-sf6s/f01/expectedResult.json
+++ b/test-fixtures/remove-orphanded-sf6s/f01/expectedResult.json
@@ -1,0 +1,35 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01" },
+      { "code": "a", "value": "Zabara, Olena,"},
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "600", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-02" },
+      { "code": "a", "value": "FOO"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "653", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "term"} ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "500-00/(N" },
+      { "code": "a", "value": "Lorum ipsum." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "100-01/(N" },
+      { "code": "a", "value": "Забара, Олена," },
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "600-02" },
+      { "code": "a", "value": "BAR"},
+      { "code": "e", "value": "whatever" }
+    ]}
+
+  ],
+  "leader": ""
+}

--- a/test-fixtures/remove-orphanded-sf6s/f01/metadata.json
+++ b/test-fixtures/remove-orphanded-sf6s/f01/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "01: valid $6, no orphaned occurence numbers ",
+  "enabled": true,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/remove-orphanded-sf6s/f01/record.json
+++ b/test-fixtures/remove-orphanded-sf6s/f01/record.json
@@ -1,0 +1,34 @@
+{
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01" },
+      { "code": "a", "value": "Zabara, Olena,"},
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "600", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-02" },
+      { "code": "a", "value": "FOO"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "653", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "term"} ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "500-00/(N" },
+      { "code": "a", "value": "Lorum ipsum." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "100-01/(N" },
+      { "code": "a", "value": "Забара, Олена," },
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "600-02" },
+      { "code": "a", "value": "BAR"},
+      { "code": "e", "value": "whatever" }
+    ]}
+
+  ],
+  "leader": ""
+}

--- a/test-fixtures/remove-orphanded-sf6s/f02/expectedResult.json
+++ b/test-fixtures/remove-orphanded-sf6s/f02/expectedResult.json
@@ -1,0 +1,40 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01" },
+      { "code": "a", "value": "Zabara, Olena,"},
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "600", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "FOO600"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "FOO700"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "500-00/(N" },
+      { "code": "a", "value": "Lorum ipsum." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "100-01/(N" },
+      { "code": "a", "value": "Забара, Олена," },
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "700-00" },
+      { "code": "a", "value": "BAR"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "810-00" },
+      { "code": "a", "value": "Tässä kentässä hudin esiintymämumero muuttuu 00:ksi"}
+    ]}
+
+  ],
+  "leader": ""
+}

--- a/test-fixtures/remove-orphanded-sf6s/f02/metadata.json
+++ b/test-fixtures/remove-orphanded-sf6s/f02/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "F02: $6 has gaps in occurence numebers",
+  "enabled": true,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/remove-orphanded-sf6s/f02/record.json
+++ b/test-fixtures/remove-orphanded-sf6s/f02/record.json
@@ -1,0 +1,43 @@
+{
+  "fields": [
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01" },
+      { "code": "a", "value": "Zabara, Olena,"},
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "600", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-03" },
+      { "code": "a", "value": "FOO600"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-05" },
+      { "code": "a", "value": "FOO700"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-123" }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "500-00/(N" },
+      { "code": "a", "value": "Lorum ipsum." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "100-01/(N" },
+      { "code": "a", "value": "Забара, Олена," },
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "700-02" },
+      { "code": "a", "value": "BAR"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "810-208" },
+      { "code": "a", "value": "Tässä kentässä hudin esiintymämumero muuttuu 00:ksi"}
+    ]}
+
+  ]
+}

--- a/test-fixtures/remove-orphanded-sf6s/v01/expectedResult.json
+++ b/test-fixtures/remove-orphanded-sf6s/v01/expectedResult.json
@@ -1,0 +1,6 @@
+{
+  "message": [
+
+  ],
+  "valid": true
+}

--- a/test-fixtures/remove-orphanded-sf6s/v01/metadata.json
+++ b/test-fixtures/remove-orphanded-sf6s/v01/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "01: has only paired $6 occurrence numbers ",
+  "enabled": true,
+  "fix": false,
+  "only": false
+}

--- a/test-fixtures/remove-orphanded-sf6s/v01/record.json
+++ b/test-fixtures/remove-orphanded-sf6s/v01/record.json
@@ -1,0 +1,31 @@
+{
+  "fields": [
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01" },
+      { "code": "a", "value": "Zabara, Olena,"},
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "600", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-02" },
+      { "code": "a", "value": "FOO"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "500-00/(N" },
+      { "code": "a", "value": "Lorum ipsum." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "100-01/(N" },
+      { "code": "a", "value": "Забара, Олена," },
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "600-02" },
+      { "code": "a", "value": "BAR"},
+      { "code": "e", "value": "whatever" }
+    ]}
+
+  ]
+}

--- a/test-fixtures/remove-orphanded-sf6s/v02/expectedResult.json
+++ b/test-fixtures/remove-orphanded-sf6s/v02/expectedResult.json
@@ -1,0 +1,6 @@
+{
+  "message": [
+    "2 orphaned occurrence number field(s) detected"
+  ],
+  "valid": false
+}

--- a/test-fixtures/remove-orphanded-sf6s/v02/metadata.json
+++ b/test-fixtures/remove-orphanded-sf6s/v02/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "V02: $6 has pairless occurrence numbers",
+  "enabled": true,
+  "fix": false,
+  "only": false
+}

--- a/test-fixtures/remove-orphanded-sf6s/v02/record.json
+++ b/test-fixtures/remove-orphanded-sf6s/v02/record.json
@@ -1,0 +1,31 @@
+{
+  "fields": [
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01" },
+      { "code": "a", "value": "Zabara, Olena,"},
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "600", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-03" },
+      { "code": "a", "value": "FOO"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "500-00/(N" },
+      { "code": "a", "value": "Lorum ipsum." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "100-01/(N" },
+      { "code": "a", "value": "Забара, Олена," },
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "700-05" },
+      { "code": "a", "value": "BAR"},
+      { "code": "e", "value": "whatever" }
+    ]}
+
+  ]
+}

--- a/test-fixtures/subfield0/f01/expectedResult.json
+++ b/test-fixtures/subfield0/f01/expectedResult.json
@@ -1,0 +1,25 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    {
+      "tag": "005",
+      "value": "20220202020202.0"
+    },
+
+    { "tag": "700", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "Nimi1" },
+        { "code": "0", "value": "(FI-ASTERI-N)000654321" }
+    ]},
+    { "tag": "700", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "Nimi1" },
+        { "code": "0", "value": "https://isni.org/isni/0000000110485855" }
+    ]},
+    { "tag": "700", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Nimi1" },
+      { "code": "0", "value": "(orcid)0000-0002-1355-5633" }
+    ]}
+
+
+  ],
+  "leader": ""
+}

--- a/test-fixtures/subfield0/f01/metadata.json
+++ b/test-fixtures/subfield0/f01/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "v01: removable $0s found",
+  "enabled": true,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/subfield0/f01/record.json
+++ b/test-fixtures/subfield0/f01/record.json
@@ -1,0 +1,23 @@
+{
+  "fields": [
+    {
+      "tag": "005",
+      "value": "20220202020202.0"
+    },
+
+    { "tag": "700", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "Nimi1" },
+        { "code": "0", "value": "(FI-ASTERI-N)000654321" }
+    ]},
+    { "tag": "700", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "Nimi1" },
+        { "code": "0", "value": "https://isni.org/isni/0000000110485855" }
+    ]},
+    { "tag": "700", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Nimi1" },
+      { "code": "0", "value": "(orcid)0000-0002-1355-5633" }
+    ]}
+
+
+  ]
+}

--- a/test-fixtures/subfield0/f02/expectedResult.json
+++ b/test-fixtures/subfield0/f02/expectedResult.json
@@ -1,0 +1,26 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    {
+      "tag": "005",
+      "value": "20220202020202.0"
+    },
+
+    { "tag": "700", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "Nimi1" },
+        { "code": "0", "value": "(FI-ASTERI-N)000654321" }
+    ]},
+    { "tag": "700", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "Nimi2" },
+        { "code": "0", "value": "(FI-ASTERI-N)000654322" }
+    ]},
+    { "tag": "700", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Nimi3" },
+      { "code": "0", "value": "(FI-ASTERI-N)000654323" },
+      { "code": "0", "value": "(keep-for-now)666" }
+    ]}
+
+
+  ],
+  "leader": ""
+}

--- a/test-fixtures/subfield0/f02/metadata.json
+++ b/test-fixtures/subfield0/f02/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "v01: No $0s to remove",
+  "enabled": true,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/subfield0/f02/record.json
+++ b/test-fixtures/subfield0/f02/record.json
@@ -1,0 +1,30 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    {
+      "tag": "005",
+      "value": "20220202020202.0"
+    },
+
+    { "tag": "700", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "Nimi1" },
+        { "code": "0", "value": "(FI-ASTERI-N)000654321" },
+        { "code": "0", "value": "(orcid)0000-0002-1355-5633" }
+    ]},
+    { "tag": "700", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "Nimi2" },
+        { "code": "0", "value": "https://isni.org/isni/0000000110485855" },
+        { "code": "0", "value": "(FI-ASTERI-N)000654322" }
+    ]},
+    { "tag": "700", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Nimi3" },
+      { "code": "0", "value": "(FI-ASTERI-N)000654323" },
+      { "code": "0", "value": "https://isni.org/isni/0000000110485853" },
+      { "code": "0", "value": "(keep-for-now)666" },
+      { "code": "0", "value": "(orcid)0000-0002-1355-5633" }
+    ]}
+
+
+  ],
+  "leader": ""
+}

--- a/test-fixtures/subfield0/f03/expectedResult.json
+++ b/test-fixtures/subfield0/f03/expectedResult.json
@@ -1,0 +1,21 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    {
+      "tag": "005",
+      "value": "20220202020202.0"
+    },
+
+    { "tag": "700", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "Nimi1" },
+        { "code": "0", "value": "(FI-ASTERI-N)000654321" }
+    ]},
+    { "tag": "700", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Nimi1" },
+      { "code": "t", "value": "Removal-preventing title" },
+      { "code": "0", "value": "(FI-ASTERI-N)000654321" },
+      { "code": "0", "value": "(orcid)0000-0002-1355-5633" }
+    ]}
+  ],
+  "leader": ""
+}

--- a/test-fixtures/subfield0/f03/metadata.json
+++ b/test-fixtures/subfield0/f03/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "v01: No $0s to remove",
+  "enabled": true,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/subfield0/f03/record.json
+++ b/test-fixtures/subfield0/f03/record.json
@@ -1,0 +1,22 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    {
+      "tag": "005",
+      "value": "20220202020202.0"
+    },
+
+    { "tag": "700", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "Nimi1" },
+        { "code": "0", "value": "(FI-ASTERI-N)000654321" },
+        { "code": "0", "value": "(orcid)0000-0002-1355-5633" }
+    ]},
+    { "tag": "700", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Nimi1" },
+      { "code": "t", "value": "Removal-preventing title" },
+      { "code": "0", "value": "(FI-ASTERI-N)000654321" },
+      { "code": "0", "value": "(orcid)0000-0002-1355-5633" }
+    ]}
+  ],
+  "leader": ""
+}

--- a/test-fixtures/subfield0/v01/expectedResult.json
+++ b/test-fixtures/subfield0/v01/expectedResult.json
@@ -1,0 +1,4 @@
+{
+  "message": [],
+  "valid": true
+}

--- a/test-fixtures/subfield0/v01/metadata.json
+++ b/test-fixtures/subfield0/v01/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "v01: removable $0s found",
+  "enabled": true,
+  "fix": false,
+  "only": false
+}

--- a/test-fixtures/subfield0/v01/record.json
+++ b/test-fixtures/subfield0/v01/record.json
@@ -1,0 +1,23 @@
+{
+  "fields": [
+    {
+      "tag": "005",
+      "value": "20220202020202.0"
+    },
+
+    { "tag": "700", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "Nimi1" },
+        { "code": "0", "value": "(FI-ASTERI-N)000654321" }
+    ]},
+    { "tag": "700", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "Nimi1" },
+        { "code": "0", "value": "https://isni.org/isni/0000000110485855" }
+    ]},
+    { "tag": "700", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Nimi1" },
+      { "code": "0", "value": "(orcid)0000-0002-1355-5633" }
+    ]}
+
+
+  ]
+}

--- a/test-fixtures/subfield0/v02/expectedResult.json
+++ b/test-fixtures/subfield0/v02/expectedResult.json
@@ -1,0 +1,8 @@
+{
+  "message": [
+    "Contains deletable $0 subfield(s): 700    ‡a Nimi1 ‡0 (FI-ASTERI-N)000654321 ‡0 (orcid)0000-0002-1355-5633",
+    "Contains deletable $0 subfield(s): 700    ‡a Nimi2 ‡0 https://isni.org/isni/0000000110485855 ‡0 (FI-ASTERI-N)000654322",
+    "Contains deletable $0 subfield(s): 700    ‡a Nimi3 ‡0 (FI-ASTERI-N)000654323 ‡0 https://isni.org/isni/0000000110485853 ‡0 (keep-for-now)666 ‡0 (orcid)0000-0002-1355-5633"
+  ],
+  "valid": false
+}

--- a/test-fixtures/subfield0/v02/metadata.json
+++ b/test-fixtures/subfield0/v02/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "v01: No $0s to remove",
+  "enabled": true,
+  "fix": false,
+  "only": false
+}

--- a/test-fixtures/subfield0/v02/record.json
+++ b/test-fixtures/subfield0/v02/record.json
@@ -1,0 +1,30 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    {
+      "tag": "005",
+      "value": "20220202020202.0"
+    },
+
+    { "tag": "700", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "Nimi1" },
+        { "code": "0", "value": "(FI-ASTERI-N)000654321" },
+        { "code": "0", "value": "(orcid)0000-0002-1355-5633" }
+    ]},
+    { "tag": "700", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "Nimi2" },
+        { "code": "0", "value": "https://isni.org/isni/0000000110485855" },
+        { "code": "0", "value": "(FI-ASTERI-N)000654322" }
+    ]},
+    { "tag": "700", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Nimi3" },
+      { "code": "0", "value": "(FI-ASTERI-N)000654323" },
+      { "code": "0", "value": "https://isni.org/isni/0000000110485853" },
+      { "code": "0", "value": "(keep-for-now)666" },
+      { "code": "0", "value": "(orcid)0000-0002-1355-5633" }
+    ]}
+
+
+  ],
+  "leader": ""
+}


### PR DESCRIPTION
Four new validators/fixers

- multiple-subfield-0.js : if Asteri $0 is present, remove isni and orcid ids (keep the rest for now)
- reindexSubfield6OccurenceNumbers.js: start from 01 and leave no gaps
- removeDuplicateDatafields.js: duplicate field removal, supports also $6 chains, and $8 chains, but not $6+$8 combos (as in test https://github.com/NatLibFi/marc-record-validators-melinda/tree/reducers20230303/test-fixtures/remove-duplicate-datafields/f06 which currently does nothing)
- resolveOrphanedSubfield6s.js: handle $6 subfields where occurence number is pairless