### PR TITLE
Add punctuation2 and removeInferiorDataFields, update removeDuplicateDatafields & maintenance update

### DIFF
--- a/.github/workflows/melinda-node-tests.yml
+++ b/.github/workflows/melinda-node-tests.yml
@@ -25,7 +25,7 @@ jobs:
       env:
         NPM_CONFIG_IGNORE_SCRIPTS: true
     - run: npm audit --package-lock-only --production --audit-level=moderate
-    - run: npm ci
+    - run: npm i
     - run: npm test
     - run: npm run build --if-present
 
@@ -55,7 +55,7 @@ jobs:
         with:
           node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
-      - run: npm ci
+      - run: npm i
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.MARC_RECORD_VALIDATORS_MELINDA_NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@natlibfi/marc-record-validators-melinda",
-  "version": "10.2.3",
+  "version": "10.3.0-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@natlibfi/marc-record-validators-melinda",
-      "version": "10.2.3",
+      "version": "10.3.0-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@babel/register": "^7.18.9",
@@ -16,7 +16,7 @@
         "cld3-asm": "^3.1.1",
         "clone": "^2.1.2",
         "debug": "^4.3.4",
-        "isbn3": "^1.1.30",
+        "isbn3": "^1.1.34",
         "langs": "^2.0.0",
         "node-fetch": "^2.6.8",
         "xml2js": ">=0.4.23 <1.0.0"
@@ -59,12 +59,12 @@
       }
     },
     "node_modules/@babel/cli": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.20.7.tgz",
-      "integrity": "sha512-WylgcELHB66WwQqItxNILsMlaTd8/SO6SgTTjMp4uCI7P4QyH1r3nqgFmO3BfM4AtfniHgFMH3EpYFj/zynBkQ==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.21.0.tgz",
+      "integrity": "sha512-xi7CxyS8XjSyiwUGCfwf+brtJxjW1/ZTcBUkP10xawIEXLX5HzLn+3aXkgxozcP2UhRhtKTmQurw9Uaes7jZrA==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.8",
+        "@jridgewell/trace-mapping": "^0.3.17",
         "commander": "^4.0.1",
         "convert-source-map": "^1.1.0",
         "fs-readdir-recursive": "^1.1.0",
@@ -99,28 +99,28 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.20.10",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.10.tgz",
-      "integrity": "sha512-sEnuDPpOJR/fcafHMjpcpGN5M2jbUGUHwmuWKM/YdPzeEDJg8bgmbcWQFUfE32MQjti1koACvoPVsDe8Uq+idg==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.21.0.tgz",
+      "integrity": "sha512-gMuZsmsgxk/ENC3O/fRw5QY8A9/uxQbbCEypnLIiYYc/qVJtEV7ouxC3EllIIwNzMqAQee5tanFabWsUOutS7g==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.20.12",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.12.tgz",
-      "integrity": "sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.3.tgz",
+      "integrity": "sha512-qIJONzoa/qiHghnm0l1n4i/6IIziDpzqc36FBs4pzMhDUraHqponwJLiAKm1hGLP3OSB/TVNz6rMwVGpwxxySw==",
       "dependencies": {
-        "@ampproject/remapping": "^2.1.0",
+        "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.20.7",
+        "@babel/generator": "^7.21.3",
         "@babel/helper-compilation-targets": "^7.20.7",
-        "@babel/helper-module-transforms": "^7.20.11",
-        "@babel/helpers": "^7.20.7",
-        "@babel/parser": "^7.20.7",
+        "@babel/helper-module-transforms": "^7.21.2",
+        "@babel/helpers": "^7.21.0",
+        "@babel/parser": "^7.21.3",
         "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.20.12",
-        "@babel/types": "^7.20.7",
+        "@babel/traverse": "^7.21.3",
+        "@babel/types": "^7.21.3",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -136,9 +136,9 @@
       }
     },
     "node_modules/@babel/eslint-parser": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.19.1.tgz",
-      "integrity": "sha512-AqNf2QWt1rtu2/1rLswy6CDP7H9Oh3mMhk177Y67Rg8d7RD9WfOLLv8CGn6tisFvS2htm86yIe1yLF6I1UDaGQ==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.21.3.tgz",
+      "integrity": "sha512-kfhmPimwo6k4P8zxNs8+T7yR44q1LdpsZdE1NkCsVlfiuTPRfnGgjaF8Qgug9q9Pou17u6wneYF0lDCZJATMFg==",
       "dev": true,
       "dependencies": {
         "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
@@ -154,12 +154,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.7.tgz",
-      "integrity": "sha512-7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.3.tgz",
+      "integrity": "sha512-QS3iR1GYC/YGUnW7IdggFeN5c1poPUurnGttOV/bZgPGV+izC/D8HnD6DLwod0fsatNyVn1G3EVWMYIF0nHbeA==",
       "dependencies": {
-        "@babel/types": "^7.20.7",
+        "@babel/types": "^7.21.3",
         "@jridgewell/gen-mapping": "^0.3.2",
+        "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
       },
       "engines": {
@@ -223,15 +224,15 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.20.12",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.20.12.tgz",
-      "integrity": "sha512-9OunRkbT0JQcednL0UFvbfXpAsUXiGjUk0a7sN8fUXX7Mue79cUSMjHGDRRi/Vz9vYlpIhLV5fMD5dKoMhhsNQ==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.21.0.tgz",
+      "integrity": "sha512-Q8wNiMIdwsv5la5SPxNYzzkPnjgC0Sy0i7jLkVOCdllu/xcVNkr3TeZzbHBJrj+XXRqzX5uCyCoV9eu6xUG7KQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
         "@babel/helper-environment-visitor": "^7.18.9",
-        "@babel/helper-function-name": "^7.19.0",
-        "@babel/helper-member-expression-to-functions": "^7.20.7",
+        "@babel/helper-function-name": "^7.21.0",
+        "@babel/helper-member-expression-to-functions": "^7.21.0",
         "@babel/helper-optimise-call-expression": "^7.18.6",
         "@babel/helper-replace-supers": "^7.20.7",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
@@ -245,13 +246,13 @@
       }
     },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.20.5.tgz",
-      "integrity": "sha512-m68B1lkg3XDGX5yCvGO0kPx3v9WIYLnzjKfPcQiwntEQa5ZeRkPmo2X/ISJc8qxWGfwUr+kvZAeEzAwLec2r2w==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.21.0.tgz",
+      "integrity": "sha512-N+LaFW/auRSWdx7SHD/HiARwXQju1vXTW4fKr4u5SgBUTm51OKEjKgj+cs00ggW3kEvNqwErnlwuq7Y3xBe4eg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
-        "regexpu-core": "^5.2.1"
+        "regexpu-core": "^5.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -298,12 +299,12 @@
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
-      "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.21.0.tgz",
+      "integrity": "sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==",
       "dependencies": {
-        "@babel/template": "^7.18.10",
-        "@babel/types": "^7.19.0"
+        "@babel/template": "^7.20.7",
+        "@babel/types": "^7.21.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -321,12 +322,12 @@
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.20.7.tgz",
-      "integrity": "sha512-9J0CxJLq315fEdi4s7xK5TQaNYjZw+nDVpVqr1axNGKzdrdwYBD5b4uKv3n75aABG0rCCTK8Im8Ww7eYfMrZgw==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.21.0.tgz",
+      "integrity": "sha512-Muu8cdZwNN6mRRNG6lAYErJ5X3bRevgYR2O8wN0yn7jJSnGDu6eG59RfT29JHxGUovyfrh6Pj0XzmR7drNVL3Q==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.20.7"
+        "@babel/types": "^7.21.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -344,9 +345,9 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.20.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.11.tgz",
-      "integrity": "sha512-uRy78kN4psmji1s2QtbtcCSaj/LILFDp0f/ymhpQH5QY3nljUZCaNWz9X1dEj/8MBdBEFECs7yRhKn8i7NjZgg==",
+      "version": "7.21.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.21.2.tgz",
+      "integrity": "sha512-79yj2AR4U/Oqq/WOV7Lx6hUjau1Zfo4cI+JLAVYeMV5XIlbOhmjEk5ulbTc9fMpmlojzZHkUUxAiK+UKn+hNQQ==",
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-module-imports": "^7.18.6",
@@ -354,8 +355,8 @@
         "@babel/helper-split-export-declaration": "^7.18.6",
         "@babel/helper-validator-identifier": "^7.19.1",
         "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.20.10",
-        "@babel/types": "^7.20.7"
+        "@babel/traverse": "^7.21.2",
+        "@babel/types": "^7.21.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -468,9 +469,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
-      "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.21.0.tgz",
+      "integrity": "sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -491,13 +492,13 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.20.13",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.13.tgz",
-      "integrity": "sha512-nzJ0DWCL3gB5RCXbUO3KIMMsBY2Eqbx8mBpKGE/02PgyRQFcPQLbkQ1vyy596mZLaP+dAfD+R4ckASzNVmW3jg==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.21.0.tgz",
+      "integrity": "sha512-XXve0CBtOW0pd7MRzzmoyuSj0e3SEzj8pgyFxnTT1NJZL38BD1MK7yYrm8yefRPIDvNNe14xR4FdbHwpInD4rA==",
       "dependencies": {
         "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.20.13",
-        "@babel/types": "^7.20.7"
+        "@babel/traverse": "^7.21.0",
+        "@babel/types": "^7.21.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -517,9 +518,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.20.13",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.13.tgz",
-      "integrity": "sha512-gFDLKMfpiXCsjt4za2JA9oTMn70CeseCehb11kRZgvd7+F67Hih3OHOK24cRrWECJ/ljfPGac6ygXAs/C8kIvw==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.3.tgz",
+      "integrity": "sha512-lobG0d7aOfQRXh8AyklEAgZGvA4FShxo6xQbUrrT/cNBPUdIDojlokwJsQyCC/eKia7ifqM0yP+2DRZ4WKw2RQ==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -594,12 +595,12 @@
       }
     },
     "node_modules/@babel/plugin-proposal-class-static-block": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.20.7.tgz",
-      "integrity": "sha512-AveGOoi9DAjUYYuUAG//Ig69GlazLnoyzMw68VCDux+c1tsnnH/OkYcpz/5xzMkEFC6UxjR5Gw1c+iY2wOGVeQ==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.21.0.tgz",
+      "integrity": "sha512-XP5G9MWNUskFuP30IfFSEFB0Z6HzLIUcjYM4bYOPHXl7eiJ9HFv8tWj6TXTN5QODiEhDZAeI4hLok2iHFFV4hw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.20.7",
+        "@babel/helper-create-class-features-plugin": "^7.21.0",
         "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/plugin-syntax-class-static-block": "^7.14.5"
       },
@@ -742,9 +743,9 @@
       }
     },
     "node_modules/@babel/plugin-proposal-optional-chaining": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.20.7.tgz",
-      "integrity": "sha512-T+A7b1kfjtRM51ssoOfS1+wbyCVqorfyZhT99TvxxLMirPShD8CzKMRepMlCBGM5RpHMbn8s+5MMHnPstJH6mQ==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.21.0.tgz",
+      "integrity": "sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.20.2",
@@ -775,13 +776,13 @@
       }
     },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.20.5.tgz",
-      "integrity": "sha512-Vq7b9dUA12ByzB4EjQTPo25sFhY+08pQDBSZRtUAkj7lb7jahaHR5igera16QZ+3my1nYR4dKsNdYj5IjPHilQ==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0.tgz",
+      "integrity": "sha512-ha4zfehbJjc5MmXBlHec1igel5TJXXLDDRbuJ4+XT2TJcyD9/V1919BA8gMvsdHcNMBy4WBUBiRb3nw/EQUtBw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
-        "@babel/helper-create-class-features-plugin": "^7.20.5",
+        "@babel/helper-create-class-features-plugin": "^7.21.0",
         "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
       },
@@ -1048,9 +1049,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
-      "version": "7.20.11",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.20.11.tgz",
-      "integrity": "sha512-tA4N427a7fjf1P0/2I4ScsHGc5jcHPbb30xMbaTke2gxDuWpUfXDuX1FEymJwKk4tuGUvGcejAR6HdZVqmmPyw==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.21.0.tgz",
+      "integrity": "sha512-Mdrbunoh9SxwFZapeHVrwFmri16+oYotcZysSzhNIVDwIAb1UV+kvnxULSYq9J3/q5MDG+4X6w8QVgD1zhBXNQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.20.2"
@@ -1063,15 +1064,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-classes": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.20.7.tgz",
-      "integrity": "sha512-LWYbsiXTPKl+oBlXUGlwNlJZetXD5Am+CyBdqhPsDVjM9Jc8jwBJFrKhHf900Kfk2eZG1y9MAG3UNajol7A4VQ==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.21.0.tgz",
+      "integrity": "sha512-RZhbYTCEUAe6ntPehC4hlslPWosNHDox+vAs4On/mCLRLfoDVHf6hVEd7kuxr1RnHwJmxFfUM3cZiZRmPxJPXQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
         "@babel/helper-compilation-targets": "^7.20.7",
         "@babel/helper-environment-visitor": "^7.18.9",
-        "@babel/helper-function-name": "^7.19.0",
+        "@babel/helper-function-name": "^7.21.0",
         "@babel/helper-optimise-call-expression": "^7.18.6",
         "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/helper-replace-supers": "^7.20.7",
@@ -1102,9 +1103,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-destructuring": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.20.7.tgz",
-      "integrity": "sha512-Xwg403sRrZb81IVB79ZPqNQME23yhugYVqgTxAhT99h485F4f+GMELFhhOsscDUB7HCswepKeCKLn/GZvUKoBA==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.21.3.tgz",
+      "integrity": "sha512-bp6hwMFzuiE4HqYEyoGJ/V2LeIWn+hLVKc4pnj++E5XQptwhtcGmSayM029d/j2X1bPKGTlsyPwAubuU22KhMA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.20.2"
@@ -1164,12 +1165,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-for-of": {
-      "version": "7.18.8",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.18.8.tgz",
-      "integrity": "sha512-yEfTRnjuskWYo0k1mHUqrVWaZwrdq8AYbfrpqULOJOaucGSp4mNMVps+YtA8byoevxS/urwU75vyhQIxcCgiBQ==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.21.0.tgz",
+      "integrity": "sha512-LlUYlydgDkKpIY7mcBWvyPPmMcOphEyYA27Ef4xpbh1IiDNLr0kZsos2nf92vz3IccvJI25QUwp86Eo5s6HmBQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.18.6"
+        "@babel/helper-plugin-utils": "^7.20.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1242,12 +1243,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
-      "version": "7.20.11",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.20.11.tgz",
-      "integrity": "sha512-S8e1f7WQ7cimJQ51JkAaDrEtohVEitXjgCGAS2N8S31Y42E+kWwfSz83LYz57QdBm7q9diARVqanIaH2oVgQnw==",
+      "version": "7.21.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.21.2.tgz",
+      "integrity": "sha512-Cln+Yy04Gxua7iPdj6nOV96smLGjpElir5YwzF0LBPKoPlLDNJePNlrGGaybAJkd0zKRnOVXOgizSqPYMNYkzA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.20.11",
+        "@babel/helper-module-transforms": "^7.21.2",
         "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/helper-simple-access": "^7.20.2"
       },
@@ -1340,9 +1341,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-parameters": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.20.7.tgz",
-      "integrity": "sha512-WiWBIkeHKVOSYPO0pWkxGPfKeWrCJyD3NJ53+Lrp/QMSZbsVPovrVl2aWZ19D/LTVnaDv5Ap7GJ/B2CTOZdrfA==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.21.3.tgz",
+      "integrity": "sha512-Wxc+TvppQG9xWFYatvCGPvZ6+SIUxQ2ZdiBP+PHYMIjnPXD+uThCshaz4NZOnODAtBjjcVQQ/3OKs9LW28purQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.20.2"
@@ -1630,10 +1631,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/regjsgen": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@babel/regjsgen/-/regjsgen-0.8.0.tgz",
+      "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==",
+      "dev": true
+    },
     "node_modules/@babel/runtime": {
-      "version": "7.20.13",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.13.tgz",
-      "integrity": "sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
+      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
       "dependencies": {
         "regenerator-runtime": "^0.13.11"
       },
@@ -1655,18 +1662,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.20.13",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.13.tgz",
-      "integrity": "sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.3.tgz",
+      "integrity": "sha512-XLyopNeaTancVitYZe2MlUEvgKb6YVVPXzofHgqHijCImG33b/uTurMS488ht/Hbsb2XK3U2BnSTxKVNGV3nGQ==",
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.20.7",
+        "@babel/generator": "^7.21.3",
         "@babel/helper-environment-visitor": "^7.18.9",
-        "@babel/helper-function-name": "^7.19.0",
+        "@babel/helper-function-name": "^7.21.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.20.13",
-        "@babel/types": "^7.20.7",
+        "@babel/parser": "^7.21.3",
+        "@babel/types": "^7.21.3",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -1675,9 +1682,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.7.tgz",
-      "integrity": "sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.3.tgz",
+      "integrity": "sha512-sBGdETxC+/M4o/zKC0sl6sjWv62WFR/uzxrJ6uYyMLZOUlPnwzw0tKgVHOXxaAd5l2g8pEDM5RZ495GPQI77kg==",
       "dependencies": {
         "@babel/helper-string-parser": "^7.19.4",
         "@babel/helper-validator-identifier": "^7.19.1",
@@ -1687,15 +1694,48 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.4.1.tgz",
+      "integrity": "sha512-BISJ6ZE4xQsuL/FmsyRaiffpq977bMlsKfGHTQrOGFErfByxIe6iZTxPf/00Zon9b9a7iUykfQwejN3s2ZW/Bw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
-      "integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.1.tgz",
+      "integrity": "sha512-eFRmABvW2E5Ho6f5fHLqgena46rOj7r7OKHYfLElqcBfGFHHpjBhivyi5+jOEQuSpdc/1phIZJlbC2te+tZNIw==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.4.0",
+        "espree": "^9.5.0",
         "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
@@ -1717,9 +1757,9 @@
       "dev": true
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "13.19.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
-      "integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
+      "version": "13.20.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -1753,6 +1793,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.36.0.tgz",
+      "integrity": "sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1985,13 +2034,13 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.49.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.49.0.tgz",
-      "integrity": "sha512-clpROBOiMIzpbWNxCe1xDK14uPZh35u4QaZO1GddilEzoCLAEz4szb51rBpdgurs5k2YzPtJeTEN3qVbG+LRUQ==",
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.56.0.tgz",
+      "integrity": "sha512-jGYKyt+iBakD0SA5Ww8vFqGpoV2asSjwt60Gl6YcO8ksQ8s2HlUEyHBMSa38bdLopYqGf7EYQMUIGdT/Luw+sw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.49.0",
-        "@typescript-eslint/visitor-keys": "5.49.0"
+        "@typescript-eslint/types": "5.56.0",
+        "@typescript-eslint/visitor-keys": "5.56.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2002,9 +2051,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.49.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.49.0.tgz",
-      "integrity": "sha512-7If46kusG+sSnEpu0yOz2xFv5nRz158nzEXnJFCGVEHWnuzolXKwrH5Bsf9zsNlOQkyZuk0BZKKoJQI+1JPBBg==",
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.56.0.tgz",
+      "integrity": "sha512-JyAzbTJcIyhuUhogmiu+t79AkdnqgPUEsxMTMc/dCZczGMJQh1MK2wgrju++yMN6AWroVAy2jxyPcPr3SWCq5w==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2015,13 +2064,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.49.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.49.0.tgz",
-      "integrity": "sha512-PBdx+V7deZT/3GjNYPVQv1Nc0U46dAHbIuOG8AZ3on3vuEKiPDwFE/lG1snN2eUB9IhF7EyF7K1hmTcLztNIsA==",
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.56.0.tgz",
+      "integrity": "sha512-41CH/GncsLXOJi0jb74SnC7jVPWeVJ0pxQj8bOjH1h2O26jXN3YHKDT1ejkVz5YeTEQPeLCCRY0U2r68tfNOcg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.49.0",
-        "@typescript-eslint/visitor-keys": "5.49.0",
+        "@typescript-eslint/types": "5.56.0",
+        "@typescript-eslint/visitor-keys": "5.56.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2075,18 +2124,18 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.49.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.49.0.tgz",
-      "integrity": "sha512-cPJue/4Si25FViIb74sHCLtM4nTSBXtLx1d3/QT6mirQ/c65bV8arBEebBJJizfq8W2YyMoPI/WWPFWitmNqnQ==",
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.56.0.tgz",
+      "integrity": "sha512-XhZDVdLnUJNtbzaJeDSCIYaM+Tgr59gZGbFuELgF7m0IY03PlciidS7UQNKLE0+WpUTn1GlycEr6Ivb/afjbhA==",
       "dev": true,
       "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.49.0",
-        "@typescript-eslint/types": "5.49.0",
-        "@typescript-eslint/typescript-estree": "5.49.0",
+        "@typescript-eslint/scope-manager": "5.56.0",
+        "@typescript-eslint/types": "5.56.0",
+        "@typescript-eslint/typescript-estree": "5.56.0",
         "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
       },
       "engines": {
@@ -2134,12 +2183,12 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.49.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.49.0.tgz",
-      "integrity": "sha512-v9jBMjpNWyn8B6k/Mjt6VbUS4J1GvUlR4x3Y+ibnP1z7y7V4n0WRz+50DY6+Myj0UaXVSuUlHohO+eZ8IJEnkg==",
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.56.0.tgz",
+      "integrity": "sha512-1mFdED7u5bZpX6Xxf5N9U2c18sb+8EvU3tyOIj6LQZ5OOvnmj8BVeNNP603OFPm5KkS1a7IvCIcwrdHXaEMG/Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.49.0",
+        "@typescript-eslint/types": "5.56.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -2401,9 +2450,9 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.21.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
-      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+      "version": "4.21.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+      "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
       "funding": [
         {
           "type": "opencollective",
@@ -2415,10 +2464,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001400",
-        "electron-to-chromium": "^1.4.251",
-        "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.9"
+        "caniuse-lite": "^1.0.30001449",
+        "electron-to-chromium": "^1.4.284",
+        "node-releases": "^2.0.8",
+        "update-browserslist-db": "^1.0.10"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2481,9 +2530,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001448",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001448.tgz",
-      "integrity": "sha512-tq2YI+MJnooG96XpbTRYkBxLxklZPOdLmNIOdIhvf7SNJan6u5vCKum8iT7ZfCt70m1GPkuC7P3TtX6UuhupuA==",
+      "version": "1.0.30001470",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001470.tgz",
+      "integrity": "sha512-065uNwY6QtHCBOExzbV6m236DDhYCCtPmQUCoQtwkVqzud8v5QPidoMr6CoMkC2nfp6nksjttqWQRRh75LqUmA==",
       "funding": [
         {
           "type": "opencollective",
@@ -2665,9 +2714,9 @@
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
     },
     "node_modules/core-js": {
-      "version": "3.27.2",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.27.2.tgz",
-      "integrity": "sha512-9ashVQskuh5AZEZ1JdQWp1GqSoC1e1G87MzRqg2gIfVAQ7Qn9K+uFj8EcniUFA4P2NLZfV+TOlX1SzoKfo+s7w==",
+      "version": "3.29.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.29.1.tgz",
+      "integrity": "sha512-+jwgnhg6cQxKYIIjGtAHq2nwUOolo9eoFZ4sHfUH09BLXBgxnH4gA0zEd+t+BO2cNB8idaBtZFcFTRjQJRJmAw==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -2676,12 +2725,12 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.27.2",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.27.2.tgz",
-      "integrity": "sha512-welaYuF7ZtbYKGrIy7y3eb40d37rG1FvzEOfe7hSLd2iD6duMDqUhRfSvCGyC46HhR6Y8JXXdZ2lnRUMkPBpvg==",
+      "version": "3.29.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.29.1.tgz",
+      "integrity": "sha512-QmchCua884D8wWskMX8tW5ydINzd8oSJVx38lx/pVkFGqztxt73GYre3pm/hyYq8bPf+MW5In4I/uRShFDsbrA==",
       "dev": true,
       "dependencies": {
-        "browserslist": "^4.21.4"
+        "browserslist": "^4.21.5"
       },
       "funding": {
         "type": "opencollective",
@@ -2764,9 +2813,9 @@
       "dev": true
     },
     "node_modules/deepmerge-ts": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-4.2.2.tgz",
-      "integrity": "sha512-Ka3Kb21tiWjvQvS9U+1Dx+aqFAHsdTnMdYptLTmC2VAmDFMugWMY1e15aTODstipmCun8iNuqeSfcx6rsUUk0Q==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-4.3.0.tgz",
+      "integrity": "sha512-if3ZYdkD2dClhnXR5reKtG98cwyaRT1NeugQoAPTTfsOpV9kqyeiBF9Qa5RHjemb3KzD5ulqygv6ED3t5j9eJw==",
       "dev": true,
       "engines": {
         "node": ">=12.4.0"
@@ -2821,9 +2870,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.284",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
-      "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA=="
+      "version": "1.4.340",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.340.tgz",
+      "integrity": "sha512-zx8hqumOqltKsv/MF50yvdAlPF9S/4PXbyfzJS6ZGhbddGkRegdwImmfSVqCkEziYzrIGZ/TlrzBND4FysfkDg=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -2867,12 +2916,15 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.32.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.32.0.tgz",
-      "integrity": "sha512-nETVXpnthqKPFyuY2FNjz/bEd6nbosRgKbkgS/y1C7LJop96gYHWpiguLecMHQ2XCPxn77DS0P+68WzG6vkZSQ==",
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.36.0.tgz",
+      "integrity": "sha512-Y956lmS7vDqomxlaaQAHVmeb4tNMp2FWIvU/RnU5BD3IKMD/MJPr76xdyr68P8tV1iNMvN2mRK0yy3c+UjL+bw==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.4.1",
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@eslint/eslintrc": "^2.0.1",
+        "@eslint/js": "8.36.0",
         "@humanwhocodes/config-array": "^0.11.8",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -2883,10 +2935,9 @@
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^7.1.1",
-        "eslint-utils": "^3.0.0",
         "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.4.0",
-        "esquery": "^1.4.0",
+        "espree": "^9.5.0",
+        "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
@@ -2907,7 +2958,6 @@
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
-        "regexpp": "^3.2.0",
         "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0"
@@ -3006,24 +3056,6 @@
       },
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/eslint-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-      "dev": true,
-      "dependencies": {
-        "eslint-visitor-keys": "^2.0.0"
-      },
-      "engines": {
-        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      },
-      "peerDependencies": {
-        "eslint": ">=5"
       }
     },
     "node_modules/eslint-visitor-keys": {
@@ -3162,9 +3194,9 @@
       }
     },
     "node_modules/eslint/node_modules/globals": {
-      "version": "13.19.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
-      "integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
+      "version": "13.20.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -3267,9 +3299,9 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
-      "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.0.tgz",
+      "integrity": "sha512-JPbJGhKc47++oo4JkEoTe2wjy4fmMwvFpgJT9cQzmfXKp22Dr6Hf1tdCteLz1h0P3t+mGvWZ+4Uankvh8+c6zw==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.8.0",
@@ -3306,9 +3338,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
       "dev": true,
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -3707,9 +3739,9 @@
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
     "node_modules/grapheme-splitter": {
@@ -4133,9 +4165,9 @@
       }
     },
     "node_modules/js-sdsl": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
-      "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz",
+      "integrity": "sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -4720,9 +4752,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
-      "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A=="
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
+      "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w=="
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -5287,27 +5319,15 @@
         "@babel/runtime": "^7.8.4"
       }
     },
-    "node_modules/regexpp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      }
-    },
     "node_modules/regexpu-core": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.2.2.tgz",
-      "integrity": "sha512-T0+1Zp2wjF/juXMrMxHxidqGYn8U4R+zleSJhX9tQ1PUsS8a9UtYfbsF9LdiVgNX3kiX8RNaKM42nfSgvFJjmw==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.3.2.tgz",
+      "integrity": "sha512-RAM5FlZz+Lhmo7db9L298p2vHP5ZywrVXmVXpmAD9GuL5MPH6t9ROw1iA/wfHkQ76Qe7AaPF0nGuim96/IrQMQ==",
       "dev": true,
       "dependencies": {
+        "@babel/regjsgen": "^0.8.0",
         "regenerate": "^1.4.2",
         "regenerate-unicode-properties": "^10.1.0",
-        "regjsgen": "^0.7.1",
         "regjsparser": "^0.9.1",
         "unicode-match-property-ecmascript": "^2.0.0",
         "unicode-match-property-value-ecmascript": "^2.1.0"
@@ -5315,12 +5335,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/regjsgen": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.7.1.tgz",
-      "integrity": "sha512-RAt+8H2ZEzHeYWxZ3H2z6tF18zyyOnlcdaafLrm21Bguj7uZy6ULibiAFdXEtKQY4Sy7wDTwDiOazasMLc4KPA==",
-      "dev": true
     },
     "node_modules/regjsparser": {
       "version": "0.9.1",
@@ -5778,9 +5792,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
+      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -5788,7 +5802,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=12.20"
       }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "git@github.com:natlibfi/marc-record-validators-melinda.git"
   },
   "license": "MIT",
-  "version": "10.2.3",
+  "version": "10.3.0-alpha.1",
   "main": "./dist/index.js",
   "publishConfig": {
     "access": "public"
@@ -41,7 +41,7 @@
     "@natlibfi/marc-record-validate": "^7.0.3",
     "cld3-asm": "^3.1.1",
     "debug": "^4.3.4",
-    "isbn3": "^1.1.30",
+    "isbn3": "^1.1.34",
     "langs": "^2.0.0",
     "node-fetch": "^2.6.8",
     "xml2js": ">=0.4.23 <1.0.0",

--- a/src/punctuation2.js
+++ b/src/punctuation2.js
@@ -1,0 +1,398 @@
+/*
+* punctuation.js -- try and fix a marc field punctuation
+*
+* Author(s): Nicholas Volk <nicholas.volk@helsinki.fi>
+*
+* NOTE #1: https://www.kiwi.fi/display/kumea/Loppupisteohje is implemented via another validator/fixer.(ending-punctuation)
+* NOTE #2: Validator/fixer punctuation does similar stuff, but focuses on X00 fields.
+*/
+import {validateSingleField} from './ending-punctuation';
+// import createDebugLogger from 'debug';
+import {fieldToString, nvdebug} from './utils';
+import clone from 'clone';
+
+// const debug = createDebugLogger('@natlibfi/marc-record-validators-melinda/punctuation2');
+
+export default function () {
+  return {
+    description: 'Add punctuation to data fields',
+    validate, fix
+  };
+
+  function fix(record) {
+    nvdebug('Add punctuation to data fields: fixer');
+    const res = {message: [], fix: [], valid: true};
+    record.fields.forEach(f => fieldFixPunctuation(f));
+    return res;
+  }
+
+  function validate(record) {
+    nvdebug('Add punctuation to data fields: validate');
+
+    const fieldsNeedingModification = record.fields.filter(f => fieldNeedsPunctuation(f));
+
+
+    const values = fieldsNeedingModification.map(f => fieldToString(f));
+    const newValues = fieldsNeedingModification.map(f => fieldGetFixedString(f));
+
+    const messages = values.map((val, i) => `'${val}' => '${newValues[i]}'`);
+
+    const res = {message: messages};
+
+    res.valid = res.message.length < 1; // eslint-disable-line functional/immutable-data
+    return res;
+  }
+}
+
+
+function fieldGetFixedString(field) {
+  const cloneField = clone(field);
+  cloneField.subfields.forEach((sf, i) => {
+    // NB! instead of next subfield, we should actually get next *non-control-subfield*!!!
+    // (In plain English: We should skip $0 - $9 at least, maybe $w as well...)
+    subfieldFixPunctuation(cloneField.tag, sf, i + 1 < cloneField.subfields.length ? cloneField.subfields[i + 1] : null);
+  });
+  return fieldToString(cloneField);
+}
+
+function fieldNeedsPunctuation(field) {
+  if (!field.subfields) {
+    return false;
+  }
+
+  const originalFieldAsString = fieldToString(field);
+  const modifiedFieldAsString = fieldGetFixedString(field);
+
+  return modifiedFieldAsString !== originalFieldAsString;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////
+// <= Above code is written for the validator logic <=                             //
+// => Everything below was originally transferred from reducers' punctuation.js => //
+/////////////////////////////////////////////////////////////////////////////////////
+
+
+//const stripCrap = / *[-;:,+]+$/u;
+const commaNeedsPuncAfter = /(?:[a-z0-9A-Z]|å|ä|ö|Å|Ä|Ö|\))$/u;
+const defaultNeedsPuncAfter = /(?:[a-z0-9A-Z]|å|ä|ö|Å|Ä|Ö)$/u;
+const defaultNeedsPuncAfter2 = /(?:[\]a-zA-Z0-9)]|ä|å|ö|Å|Ä|Ö)$/u;
+const blocksPuncRHS = /^(?:\()/u;
+const allowsPuncRHS = /^(?:[A-Za-z0-9]|å|ä|ö|Å|Ä|Ö)/u;
+
+const dotIsProbablyPunc = /(?:[a-z0-9)]|å|ä|ö)\.$/u;
+const puncIsProbablyPunc = /(?:[a-z0-9)]|å|ä|ö) ?[.,:;]$/u;
+// NB! 65X: Finnish terms don't use punctuation, but international ones do. Neither one is currently (2021-11-08) coded here.
+
+// Will unfortunately trigger "Sukunimi, Th." type:
+const removeColons = {'code': 'abcdefghijklmnopqrstuvwxyz', 'remove': / *[;:]$/u};
+const removeX00Comma = {'code': 'abcqde', 'followedBy': 'abcqde#01459', 'context': /.,$/u, 'remove': /,$/u};
+const cleanRHS = {'code': 'abcd', 'followedBy': 'bcde', 'context': /(?:(?:[a-z0-9]|å|ä|ö)\.|,)$/u, 'contextRHS': blocksPuncRHS, 'remove': /[.,]$/u};
+const cleanX00dCommaOrDot = {'code': 'd', 'followedBy': 'et#01459', 'context': /[0-9]-[,.]$/u, 'remove': /[,.]$/u};
+const cleanX00aDot = {'code': 'abcde', 'followedBy': 'cdegj', 'context': dotIsProbablyPunc, 'remove': /\.$/u};
+const cleanCorruption = {'code': 'abcdefghijklmnopqrstuvwxyz', 'remove': / \.$/u};
+// These $e dot removals are tricky: before removing the comma, we should know that it ain't an abbreviation such as "esitt."...
+const cleanX00eDot = {'code': 'e', 'followedBy': 'egj#059', 'context': /(?:[ai]ja|jä)[.,]$/u, 'remove': /\.$/u};
+
+const X00RemoveDotAfterBracket = {'code': 'cq', 'context': /\)\.$/u, 'remove': /\.$/u};
+// 390, 800, 810, 830...
+const cleanPuncBeforeLanguage = {'code': 'atvxyz', 'followedBy': 'l', 'context': puncIsProbablyPunc, 'remove': / *[.,:;]$/u};
+
+
+const addX00aComma = {'add': ',', 'code': 'abcqdej', 'followedBy': 'cdeg', 'context': commaNeedsPuncAfter, 'contextRHS': allowsPuncRHS};
+const addX00aComma2 = {'add': ',', 'code': 'abcdej', 'followedBy': 'cdeg', 'context': /(?:[A-Z]|Å|Ä|Ö)\.$/u, 'contextRHS': allowsPuncRHS};
+const addX00aDot = {'add': '.', 'code': 'abcde', 'followedBy': '#tu0159', 'context': defaultNeedsPuncAfter};
+
+const addX10bDot = {'name': 'Add X10 pre-$b dot', 'add': '.', 'code': 'ab', 'followedBy': 'b', 'context': defaultNeedsPuncAfter};
+const addX10eComma = {'add': ',', 'code': 'abe', 'followedBy': 'e', 'context': defaultNeedsPuncAfter};
+const addX10Dot = {'name': 'Add X10 final dot', 'add': '.', 'code': 'abe', 'followedBy': '#0159', 'context': defaultNeedsPuncAfter};
+const addLanguageComma = {'name': 'Add comma before 810$l', 'add': ',', 'code': 'tv', 'followedBy': 'l', 'context': defaultNeedsPuncAfter2};
+const addColonToRelationshipInformation = {'name': 'Add \':\' to 7X0 $i relationship info', 'add': ':', 'code': 'i', 'context': /[a-z)åäö]$/u};
+
+// 490:
+const addSemicolonBeforeVolumeDesignation = {'name': 'Add " ;" before $v', 'add': ' ;', 'code': 'atxy', 'followedBy': 'v', 'context': /[^;]$/u};
+
+const NONE = 0;
+const ADD = 2;
+const REMOVE = 1;
+const REMOVE_AND_ADD = 3;
+
+// Crappy punctuation consists of various crap that is somewhat common.
+// We strip crap for merge decisions. We are not trying to actively remove crap here.
+
+const removeX00Whatever = [removeX00Comma, cleanX00aDot, cleanX00eDot, cleanCorruption, cleanX00dCommaOrDot, cleanRHS, X00RemoveDotAfterBracket, removeColons, cleanPuncBeforeLanguage];
+const removeX10Whatever = [removeX00Comma, cleanX00aDot, cleanX00eDot, cleanCorruption, removeColons, cleanPuncBeforeLanguage];
+
+const cleanCrappyPunctuationRules = {
+  '100': removeX00Whatever,
+  '110': removeX10Whatever,
+  '600': removeX00Whatever,
+  '610': removeX10Whatever,
+  '700': removeX00Whatever,
+  '710': removeX10Whatever,
+  '800': removeX00Whatever,
+  '810': removeX10Whatever,
+  '245': [{'code': 'ab', 'followedBy': '!c', 'remove': / \/$/u}],
+  '300': [
+    {'code': 'a', 'followedBy': '!b', 'remove': / *:$/u},
+    {'code': 'a', 'followedBy': 'b', 'remove': /:$/u, 'context': /[^ ]:$/u},
+    {'code': 'ab', 'followedBy': '!c', 'remove': / *;$/u},
+    {'code': 'ab', 'followedBy': 'c', 'remove': /;$/u, 'context': /[^ ];$/u},
+    {'code': 'abc', 'followedBy': '!e', 'remove': / *\+$/u},
+    {'code': 'abc', 'followedBy': '!e', 'remove': / *\+$/u, 'context': /[^ ]\+$/u}
+
+  ],
+  '490': [{'code': 'a', 'followedBy': 'xy', 'remove': / ;$/u}],
+  '773': [{'code': 'abdghiklmnopqrstuwxyz', 'followedBy': 'abdghiklmnopqrstuwxyz', 'remove': /\. -$/u}]
+
+};
+
+const cleanLegalX00Comma = {'code': 'abcde', 'followedBy': 'cdegj', 'context': /.,$/u, 'remove': /,$/u};
+// Accept upper case letters in X00$b, since they are probably Roman numerals.
+const cleanLegalX00bDot = {'code': 'b', 'followedBy': 't#01459', context: /^[IVXLCDM]+\.$/u, 'remove': /\.$/u};
+const cleanLegalX00Dot = {'code': 'abcdetvl', 'followedBy': 'tu#01459', 'context': /(?:[a-z0-9)]|å|ä|ö)\.$/u, 'remove': /\.$/u};
+const cleanLanguageComma = {'name': 'language comma', 'code': 'tv', 'followedBy': 'l', 'context': /.,$/u, 'remove': /,$/u};
+
+
+const legalX00punc = [cleanLegalX00Comma, cleanLegalX00bDot, cleanLegalX00Dot, cleanLanguageComma];
+
+const cleanLegalX10Comma = {'name': 'X10comma', 'code': 'abe', 'followedBy': 'e', 'context': /.,$/u, 'remove': /,$/u};
+const cleanLegalX10Dot = {'name': 'X10dot', 'code': 'ab', 'followedBy': 'b#059', 'context': /.\.$/u, 'remove': /\.$/u};
+
+const legalX10punc = [cleanLegalX10Comma, cleanLegalX10Dot, cleanX00eDot, cleanLanguageComma];
+
+const cleanValidPunctuationRules = {
+  '100': legalX00punc,
+  '110': legalX10punc,
+  '600': legalX00punc,
+  '610': legalX10punc,
+  '700': legalX00punc,
+  '710': legalX10punc,
+  '800': legalX00punc,
+  '810': legalX10punc,
+  '245': [
+    {'name': 'A:B', 'code': 'a', 'followedBy': 'b', 'remove': / [:;=]$/u},
+    {'name': 'AB:K', 'code': 'ab', 'followedBy': 'k', 'remove': / :$/u},
+    {'name': 'ABK:F', 'code': 'abk', 'followedBy': 'f', 'remove': /,$/u},
+    {'name': 'ABFNP:C', 'code': 'abfnp', 'followedBy': 'c', 'remove': / \/$/u},
+    {'name': 'ABN:N', 'code': 'abn', 'followedBy': 'n', 'remove': /\.$/u},
+    {'name': 'ABNP:#', 'code': 'abnp', 'followedBy': '#', 'remove': /\.$/u},
+    {'name': 'N:P', 'code': 'n', 'followedBy': 'p', 'remove': /,$/u}
+
+  ],
+  '260': [
+    {'code': 'a', 'followedBy': 'b', 'remove': / :$/u},
+    {'code': 'b', 'followedBy': 'c', 'remove': /,$/u},
+    {'code': 'c', 'followedBy': '#', 'remove': /\.$/u},
+    {'code': 'd', 'followedBy': 'e', 'remove': / :$/u},
+    {'code': 'e', 'followedBy': 'f', 'remove': /,$/u},
+    {'code': 'f', 'followedBy': '#', 'remove': /\.$/u} // Probably ')' but shouldit be removed?
+  ],
+  '264': [
+    {'code': 'a', 'followedBy': 'b', 'remove': / :$/u},
+    {'code': 'b', 'followedBy': 'c', 'remove': /,$/u},
+    {'code': 'c', 'followedBy': '#', 'remove': /\.$/u}
+  ],
+  '300': [
+    // NB! Remove crap as well, thus the '*' in / *:$/
+    {'code': 'a', 'followedBy': 'b', 'remove': / :$/u},
+    {'code': 'ab', 'followedBy': 'c', 'remove': / ;$/u},
+    {'code': 'abc', 'followedBy': 'e', 'remove': / \+$/u}
+  ],
+  '490': [
+    {'code': 'axy', 'followedBy': 'xy', 'remove': /,$/u},
+    {'code': 'axy', 'followedBy': 'v', 'remove': / *;$/u}
+  ],
+  '534': [{'code': 'p', 'followedBy': 'c', 'remove': /:$/u}]
+
+};
+
+// addColonToRelationshipInformation only applies to 700/710 but as others don't have $i, it's fine
+const addX00 = [addX00aComma, addX00aComma2, addX00aDot, addLanguageComma, addSemicolonBeforeVolumeDesignation, addColonToRelationshipInformation];
+const addX10 = [addX10bDot, addX10eComma, addX10Dot, addLanguageComma, addSemicolonBeforeVolumeDesignation, addColonToRelationshipInformation];
+const addPairedPunctuationRules = {
+  '100': addX00,
+  '110': addX10,
+  '245': [
+    // Blah! Also "$a = $b" and "$a ; $b" can be valid... But ' :' is better than nothing, I guess...
+    {'code': 'a', 'followedBy': 'b', 'add': ' :', 'context': defaultNeedsPuncAfter},
+    {'code': 'abk', 'followedBy': 'f', 'add': ',', 'context': defaultNeedsPuncAfter},
+    {'code': 'abfnp', 'followedBy': 'c', 'add': ' /', 'context': defaultNeedsPuncAfter}
+  ],
+  '260': [
+    {'code': 'a', 'followedBy': 'b', 'add': ' :', 'context': defaultNeedsPuncAfter2},
+    {'code': 'b', 'followedBy': 'c', 'add': ',', 'context': defaultNeedsPuncAfter2},
+    {'code': 'abc', 'followedBy': 'a', 'add': ' ;', 'context': defaultNeedsPuncAfter2},
+    {'code': 'e', 'followedBy': 'f', 'add': ' :', 'context': defaultNeedsPuncAfter2},
+    {'code': 'f', 'followedBy': 'g', 'add': ',', 'context': defaultNeedsPuncAfter2}
+  ],
+  '264': [
+    {'code': 'a', 'followedBy': 'b', 'add': ' :', 'context': defaultNeedsPuncAfter2},
+    {'code': 'b', 'followedBy': 'c', 'add': ',', 'context': defaultNeedsPuncAfter2},
+    // NB! The $c rule messes dotless exception "264 #4 $c p1983" up
+    // We'll need to add a hacky postprocessor for this? Add 'hasInd1': '0123' etc?
+    {'code': 'c', 'followedBy': '#', 'add': '.', 'context': defaultNeedsPuncAfter2}
+  ],
+  '300': [
+    {'code': 'a', 'followedBy': 'b', 'add': ' :', 'context': defaultNeedsPuncAfter2},
+    {'code': 'ab', 'followedBy': 'c', 'add': ' ;', 'context': defaultNeedsPuncAfter2},
+    {'code': 'abc', 'followedBy': 'e', 'add': ' +', 'context': defaultNeedsPuncAfter2}
+  ],
+  '490': [
+    {'code': 'axy', 'followedBy': 'xy', 'add': ',', 'context': defaultNeedsPuncAfter},
+    addSemicolonBeforeVolumeDesignation
+    //{'code': 'axy', 'followedBy': 'v', 'add': ' ;', 'context': defaultNeedsPuncAfter}
+  ],
+  '506': [{'code': 'a', 'followedBy': '#', 'add': '.', 'context': defaultNeedsPuncAfter2}],
+  '534': [{'code': 'p', 'followedBy': 'c', 'add': ':', 'context': defaultNeedsPuncAfter2}],
+  '600': addX00,
+  '610': addX10,
+  '700': addX00,
+  '710': addX10,
+  '800': addX00,
+  '810': addX10,
+  '830': [
+    {'code': 'axy', 'followedBy': 'xy', 'add': ',', 'context': defaultNeedsPuncAfter},
+    addSemicolonBeforeVolumeDesignation
+    //{'code': 'axy', 'followedBy': 'v', 'add': ' ;', 'context': defaultNeedsPuncAfter}
+  ]
+
+};
+
+function ruleAppliesToSubfieldCode(targetSubfieldCodes, currSubfieldCode) {
+  const negation = targetSubfieldCodes.includes('!');
+  if (negation) {
+    return !targetSubfieldCodes.includes(currSubfieldCode);
+  }
+  return targetSubfieldCodes.includes(currSubfieldCode);
+}
+
+
+function ruleAppliesToCurrentSubfield(rule, subfield) {
+  if (!ruleAppliesToSubfieldCode(rule.code, subfield.code)) {
+    return false;
+  }
+  if ('context' in rule && !subfield.value.match(rule.context)) { // njsscan-ignore: regex_injection_dos
+    return false;
+  }
+  return true;
+}
+
+function ruleAppliesToNextSubfield(rule, nextSubfield) {
+  if (!('followedBy' in rule)) { // Return true, if we are not interested in the next subfield
+    return true;
+  }
+  // The '#' existence check applies only to the RHS field. LHS always exists.
+  if (nextSubfield === null) {
+    const negation = rule.followedBy.includes('!');
+    if (negation) {
+      return !rule.followedBy.includes('#');
+    }
+    return rule.followedBy.includes('#');
+  }
+
+  if (!ruleAppliesToSubfieldCode(rule.followedBy, nextSubfield.code)) {
+    return false;
+  }
+  if ('contextRHS' in rule && !nextSubfield.value.match(rule.contextRHS)) { // njsscan-ignore: regex_injection_dos
+    return false;
+  }
+  return true;
+}
+
+function checkRule(rule, subfield1, subfield2) {
+  //const name = rule.name || 'UNNAMED';
+  if (!ruleAppliesToCurrentSubfield(rule, subfield1)) {
+    //nvdebug(`${name}: FAIL ON LHS FIELD: '$${subfield1.code} ${subfield1.value}', SF=${rule.code}`, debug);
+    return false;
+  }
+
+  // NB! This is not a perfect solution. We might have $e$0$e where $e$0 punctuation should actually be based on $e$e rules
+  if (!ruleAppliesToNextSubfield(rule, subfield2)) {
+    //const msg = subfield2 ? `${name}: FAIL ON RHS FIELD '${subfield2.code}' not in [${rule.followedBy}]` : `${name}: FAIL ON RHS FIELD`;
+    //nvdebug(msg, debug);
+    return false;
+  }
+
+  //nvdebug(`${name}: ACCEPT ${rule.code}/${subfield1.code}, SF2=${rule.followedBy}/${subfield2 ? subfield2.code : '#'}`, debug);
+  return true;
+}
+
+function applyPunctuationRules(tag, subfield1, subfield2, ruleArray = null, operation = NONE) {
+
+  /*
+  if (ruleArray === null || operation === NONE) {
+    debug(`applyPunctuation(): No rules to apply!`);
+    return;
+  }
+*/
+  if (!(`${tag}` in ruleArray) || ruleArray === null || operation === NONE) {
+
+    /*
+    if (!['020', '650'].includes(tag) || !isControlSubfieldCode(subfield1.code)) { // eslint-disable-line functional/no-conditional-statement
+      nvdebug(`No punctuation rules found for ${tag} (looking for: ‡${subfield1.code})`, debug);
+
+    }
+    */
+    return;
+  }
+
+  //nvdebug(`OP=${operation} ${tag}: '${subfield1.code}: ${subfield1.value}' ??? '${subfield2 ? subfield2.code : '#'}'`, debug);
+  const activeRules = ruleArray[tag].filter(rule => checkRule(rule, subfield1, subfield2));
+
+  activeRules.forEach(rule => {
+    const originalValue = subfield1.value;
+    if (rule.remove && [REMOVE, REMOVE_AND_ADD].includes(operation) && subfield1.value.match(rule.remove)) { // eslint-disable-line functional/no-conditional-statement
+      //nvdebug(`    PUNC REMOVAL TO BE PERFORMED FOR $${subfield1.code} '${subfield1.value}'`, debug);
+      subfield1.value = subfield1.value.replace(rule.remove, ''); // eslint-disable-line functional/immutable-data
+      //nvdebug(`    PUNC REMOVAL PERFORMED FOR '${subfield1.value}'`, debug);
+    }
+    if (rule.add && [ADD, REMOVE_AND_ADD].includes(operation)) { // eslint-disable-line functional/no-conditional-statement
+      subfield1.value += rule.add; // eslint-disable-line functional/immutable-data
+      //nvdebug(`    ADDED '${rule.add}' TO '${subfield1.value}'`, debug);
+    }
+    if (subfield1.value !== originalValue) { // eslint-disable-line functional/no-conditional-statement
+      //nvdebug(` PROCESS PUNC: '‡${subfield1.code} ${originalValue}' => '‡${subfield1.code} ${subfield1.value}'`, debug); // eslint-disable-line functional/immutable-data
+    }
+  });
+}
+
+function subfieldFixPunctuation(tag, subfield1, subfield2) {
+  applyPunctuationRules(tag, subfield1, subfield2, cleanCrappyPunctuationRules, REMOVE);
+  applyPunctuationRules(tag, subfield1, subfield2, addPairedPunctuationRules, ADD);
+}
+
+
+export function fieldStripPunctuation(field) {
+  if (!field.subfields) {
+    return field;
+  }
+
+  field.subfields.forEach((sf, i) => {
+    nvdebug(`FSP1: '${sf.value}'`);
+    applyPunctuationRules(field.tag, sf, i + 1 < field.subfields.length ? field.subfields[i + 1] : null, cleanValidPunctuationRules, REMOVE);
+    nvdebug(`FSP2: '${sf.value}'`);
+    applyPunctuationRules(field.tag, sf, i + 1 < field.subfields.length ? field.subfields[i + 1] : null, cleanCrappyPunctuationRules, REMOVE);
+    nvdebug(`FSP3: '${sf.value}'`);
+  });
+  return field;
+}
+
+export function fieldFixPunctuation(field) {
+  if (!field.subfields) {
+    return field;
+  }
+  nvdebug(`################### fieldFixPunctuation() TEST ${fieldToString(field)}`);
+
+  field.subfields.forEach((sf, i) => {
+    // NB! instead of next subfield, we should actually get next *non-control-subfield*!!!
+    // (In plain English: We should skip $0 - $9 at least, maybe $w as well...)
+    subfieldFixPunctuation(field.tag, sf, i + 1 < field.subfields.length ? field.subfields[i + 1] : null);
+  });
+
+  // Use shared code for final punctuation (sadly this does not fix intermediate punc):
+  if (field.useExternalEndPunctuation) { // eslint-disable-line functional/no-conditional-statement
+    // addFinalPunctuation(field); // local version. use shared code instead.
+    validateSingleField(field, false, true); // NB! Don't use field.tag as second argument! It's a string, not an int. 3rd arg must be true (=fix)
+  }
+  return field;
+}

--- a/src/punctuation2.spec.js
+++ b/src/punctuation2.spec.js
@@ -1,0 +1,52 @@
+import {expect} from 'chai';
+import {MarcRecord} from '@natlibfi/marc-record';
+import validatorFactory from './punctuation2';
+import {READERS} from '@natlibfi/fixura';
+import generateTests from '@natlibfi/fixugen';
+import createDebugLogger from 'debug';
+
+generateTests({
+  callback,
+  path: [__dirname, '..', 'test-fixtures', 'punctuation2'],
+  useMetadataFile: true,
+  recurse: false,
+  fixura: {
+    reader: READERS.JSON
+  },
+  mocha: {
+    before: () => testValidatorFactory()
+  }
+});
+const debug = createDebugLogger('@natlibfi/marc-record-validators-melinda/punctuation2:test');
+
+async function testValidatorFactory() {
+  const validator = await validatorFactory();
+
+  expect(validator)
+    .to.be.an('object')
+    .that.has.any.keys('description', 'validate');
+
+  expect(validator.description).to.be.a('string');
+  expect(validator.validate).to.be.a('function');
+}
+
+async function callback({getFixture, enabled = true, fix = false}) {
+  if (enabled === false) {
+    debug('TEST SKIPPED!');
+    return;
+  }
+
+  const validator = await validatorFactory();
+  const record = new MarcRecord(getFixture('record.json'));
+  const expectedResult = getFixture('expectedResult.json');
+  // console.log(expectedResult); // eslint-disable-line
+
+  if (!fix) {
+    const result = await validator.validate(record);
+    expect(result).to.eql(expectedResult);
+    return;
+  }
+
+  await validator.fix(record);
+  expect(record).to.eql(expectedResult);
+}

--- a/src/removeInferiorDataFields.js
+++ b/src/removeInferiorDataFields.js
@@ -1,0 +1,97 @@
+import createDebugLogger from 'debug';
+import {fieldToString, nvdebug} from './utils';
+
+// Relocated from melinda-marc-record-merge-reducers (and renamed)
+
+const debug = createDebugLogger('@natlibfi/marc-record-validators-melinda:removeSubsetDataFields');
+
+export default function () {
+  return {
+    description: 'Remove subset data fields. Certain exceptions apply, mainly too complited chained fields',
+    validate, fix
+  };
+
+  function fix(record) {
+    nvdebug('Fix record: remove subset data fields', debug);
+    const res = {message: [], fix: [], valid: true};
+    removeInferiorDatafields(record, true);
+    // This can not really fail...
+    return res;
+  }
+
+  function validate(record) {
+    // Check max, and check number of different indexes
+    nvdebug('Validate record: remove subset data fields', debug);
+
+    const duplicates = removeInferiorDatafields(record, false);
+
+    const res = {message: duplicates};
+
+    res.valid = res.message.length < 1; // eslint-disable-line functional/immutable-data
+    return res;
+  }
+}
+
+function deriveIndividualDeletables(record) {
+  /* eslint-disable */
+  let deletableStringsArray = [];
+
+  record.fields.forEach(field => fieldDeriveIndividualDeletables(field));
+
+  function fieldDeriveIndividualDeletables(field) {
+    const fieldAsString = fieldToString(field);
+
+    // Proof-of-concept rule:
+    let tmp = fieldAsString;
+    if (field.tag.match(/^[1678]00$/u)) {
+      while (tmp.match(/, ‡e [^‡]+\.$/)) {
+        tmp = tmp.replace(/, ‡e [^‡]+\.$/, '.');
+        deletableStringsArray.push(tmp);
+      }
+    }
+
+
+    // Remove keepless versions:
+    tmp = fieldAsString;
+    while (tmp.match(/ ‡9 [A-Z]+<KEEP>/)) {
+      tmp = tmp.replace(/ ‡9 [A-Z]+<KEEP>/, '');
+      deletableStringsArray.push(tmp);
+    }
+  }
+  /* eslint-enable */
+  return deletableStringsArray; // we should do uniq!
+
+}
+
+export function removeIndividualInferiorDatafields(record, fix = true) { // No $6 nor $8 in field
+  const deletableFieldsAsStrings = deriveIndividualDeletables(record);
+  const hits = record.fields.filter(field => isDeletableField(field));
+
+  const deletedFieldsAsStrings = hits.map(f => fieldToString(f));
+
+  if (fix) { // eslint-disable-line functional/no-conditional-statement
+    hits.forEach(field => {
+      nvdebug(`Remove inferior field: ${fieldToString(field)}`);
+      record.removeField(field);
+    });
+  }
+
+  return deletedFieldsAsStrings;
+
+  function isDeletableField(field) {
+    const fieldAsString = fieldToString(field);
+    return deletableFieldsAsStrings.includes(fieldAsString);
+  }
+}
+
+
+export function removeInferiorDatafields(record, fix = true) {
+  const removables = removeIndividualInferiorDatafields(record, fix); // Lone fields
+  //const removables8 = removeDuplicateSubfield8Chains(record, fix); // Lone subfield $8 chains
+  //const removables6 = removeDuplicateSubfield6Chains(record, fix); // Lone subfield $6 chains
+  // HOW TO HANDLE $6+$8 combos?
+
+  const removablesAll = removables; //.concat(removables8).concat(removables6);
+
+  return removablesAll;
+}

--- a/src/removeInferiorDataFields.spec.js
+++ b/src/removeInferiorDataFields.spec.js
@@ -1,0 +1,52 @@
+import {expect} from 'chai';
+import {MarcRecord} from '@natlibfi/marc-record';
+import validatorFactory from './removeInferiorDataFields';
+import {READERS} from '@natlibfi/fixura';
+import generateTests from '@natlibfi/fixugen';
+import createDebugLogger from 'debug';
+
+generateTests({
+  callback,
+  path: [__dirname, '..', 'test-fixtures', 'remove-inferior-datafields'],
+  useMetadataFile: true,
+  recurse: false,
+  fixura: {
+    reader: READERS.JSON
+  },
+  mocha: {
+    before: () => testValidatorFactory()
+  }
+});
+const debug = createDebugLogger('@natlibfi/marc-record-validators-melinda/removeInferiorDataFields:test');
+
+async function testValidatorFactory() {
+  const validator = await validatorFactory();
+
+  expect(validator)
+    .to.be.an('object')
+    .that.has.any.keys('description', 'validate');
+
+  expect(validator.description).to.be.a('string');
+  expect(validator.validate).to.be.a('function');
+}
+
+async function callback({getFixture, enabled = true, fix = false}) {
+  if (enabled === false) {
+    debug('TEST SKIPPED!');
+    return;
+  }
+
+  const validator = await validatorFactory();
+  const record = new MarcRecord(getFixture('record.json'));
+  const expectedResult = getFixture('expectedResult.json');
+  // console.log(expectedResult); // eslint-disable-line
+
+  if (!fix) {
+    const result = await validator.validate(record);
+    expect(result).to.eql(expectedResult);
+    return;
+  }
+
+  await validator.fix(record);
+  expect(record).to.eql(expectedResult);
+}

--- a/src/subfield8Utils.js
+++ b/src/subfield8Utils.js
@@ -10,7 +10,7 @@ export function isValidSubfield8(subfield) {
     return false;
   }
 
-  nvdebug(`   IS VALID $8? '${subfieldToString(subfield)}'`);
+  //nvdebug(`   IS VALID $8? '${subfieldToString(subfield)}'`);
   const match = subfield.value.match(sf8Regexp);
   //nvdebug(`   IS VALID $8? '${subfieldToString(subfield)}' vs ${match.length}}`);
   return match && match.length > 0;
@@ -32,25 +32,25 @@ export function getSubfield8LinkingNumber(subfield) {
 }
 
 
+export function fieldHasLinkingNumber(field, linkingNumber) {
+  if (!field.subfields) {
+    return false;
+  }
+  return field.subfields.some(sf => getSubfield8LinkingNumber(sf) === linkingNumber);
+}
+
 export function recordGetFieldsWithSubfield8LinkingNumber(record, linkingNumber) {
   if (linkingNumber < 1) {
     return;
   }
-  return record.fields.filter(field => relevant4GFWS8I(field));
-
-  function relevant4GFWS8I(field) {
-    if (!field.subfields) {
-      return false;
-    }
-    return field.subfields.some(sf => getSubfield8LinkingNumber(sf) === linkingNumber);
-  }
+  return record.fields.filter(field => fieldHasLinkingNumber(field, linkingNumber));
 }
 
 
-export function recordGetAllSubfield8LinkingNumbers(record) {
+export function fieldsGetAllSubfield8LinkingNumbers(fields) {
   /* eslint-disable */
   let subfield8LinkingNumbers = [];
-  record.fields.forEach(field => {
+  fields.forEach(field => {
     if (!field.subfields) {
       return;
     }
@@ -66,4 +66,9 @@ export function recordGetAllSubfield8LinkingNumbers(record) {
 
   return subfield8LinkingNumbers;
   /* eslint-enable */
+
+}
+
+export function recordGetAllSubfield8LinkingNumbers(record) {
+  return fieldsGetAllSubfield8LinkingNumbers(record.fields);
 }

--- a/test-fixtures/punctuation2/01/expectedResult.json
+++ b/test-fixtures/punctuation2/01/expectedResult.json
@@ -1,0 +1,12 @@
+{
+  "message": [
+    "'100 1  ‡a Tuisku, Sara ‡e turkulainen ‡e testaaja' => '100 1  ‡a Tuisku, Sara, ‡e turkulainen, ‡e testaaja.'",
+    "'700 1  ‡a Reipas, R. ‡d 2000- ‡e esittäjä' => '700 1  ‡a Reipas, R., ‡d 2000- ‡e esittäjä.'",
+    "'700 1  ‡a Reippaahko, R. ‡d 2000-' => '700 1  ‡a Reippaahko, R., ‡d 2000-'",
+    "'700 1  ‡a Reippaampi, R. ‡d 2000-2050 ‡e esittäjä' => '700 1  ‡a Reippaampi, R., ‡d 2000-2050, ‡e esittäjä.'",
+    "'700 1  ‡a Reippain, R. ‡d 2000-2050' => '700 1  ‡a Reippain, R., ‡d 2000-2050.'",
+    "'700 1  ‡a Nalle, P. ‡d 1926- ‡0 (FIN11)000000000' => '700 1  ‡a Nalle, P., ‡d 1926- ‡0 (FIN11)000000000'"
+  ],
+  "valid": false
+
+}

--- a/test-fixtures/punctuation2/01/metadata.json
+++ b/test-fixtures/punctuation2/01/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description":"validate 01 - fix punctuation of X00 fields. Non-X00 fields are fine",
+  "enabled": true,
+  "fix": false,
+  "only": false
+}

--- a/test-fixtures/punctuation2/01/record.json
+++ b/test-fixtures/punctuation2/01/record.json
@@ -1,0 +1,37 @@
+{
+  "leader": "01331cam a22003494i 4500",
+  "fields": [
+    { "tag": "001", "value": "000000001" },
+    { "tag": "041", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "fin" } ] },
+
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+        { "code": "a", "value": "Tuisku, Sara" },
+        { "code": "e", "value": "turkulainen" },
+        { "code": "e", "value": "testaaja" }
+      ]
+    },
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+        { "code": "a", "value": "Reipas, R." },
+        { "code": "d", "value": "2000-" },
+        { "code": "e", "value": "esittäjä" }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Reippaahko, R." },
+      { "code": "d", "value": "2000-" }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Reippaampi, R." },
+      { "code": "d", "value": "2000-2050" },
+      { "code": "e", "value": "esittäjä" }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Reippain, R." },
+      { "code": "d", "value": "2000-2050" }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Nalle, P." },
+      { "code": "d", "value": "1926-" },
+      { "code": "0", "value": "(FIN11)000000000"}
+    ]}
+  ]
+}

--- a/test-fixtures/punctuation2/02/expectedResult.json
+++ b/test-fixtures/punctuation2/02/expectedResult.json
@@ -1,0 +1,4 @@
+{
+  "message": [],
+  "valid": true
+}

--- a/test-fixtures/punctuation2/02/metadata.json
+++ b/test-fixtures/punctuation2/02/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description":"field 245 punctuation test",
+  "enabled": true,
+  "fix": false,
+  "only": false
+}

--- a/test-fixtures/punctuation2/02/record.json
+++ b/test-fixtures/punctuation2/02/record.json
@@ -1,0 +1,14 @@
+{
+  "leader": "01331cam a22003494i 4500",
+  "fields": [
+    { "tag": "100", "ind1": "1", "ind2": "0", "subfields": [
+        { "code": "a", "value": "Sukunimi, Etunimi," },
+        { "code": "e", "value": "säveltäjä." }
+      ]
+    },
+    { "tag": "245", "ind1": "1", "ind2": "0", "subfields": [
+      { "code": "a", "value": "Only valid fields in this test /" },
+      { "code": "c", "value": "Tekijä." }
+    ]}
+  ]
+}

--- a/test-fixtures/punctuation2/04/expectedResult.json
+++ b/test-fixtures/punctuation2/04/expectedResult.json
@@ -1,0 +1,7 @@
+{
+  "message": [
+    "'245 10 ‡a Manun illallinen ‡c Tellervo Koivisto' => '245 10 ‡a Manun illallinen / ‡c Tellervo Koivisto'",
+    "'245 10 ‡a Manun illallinen ‡b lentopallosta hiustöyhtöön ‡c Tellervo Koivisto' => '245 10 ‡a Manun illallinen : ‡b lentopallosta hiustöyhtöön / ‡c Tellervo Koivisto'"
+  ],
+  "valid": false
+}

--- a/test-fixtures/punctuation2/04/metadata.json
+++ b/test-fixtures/punctuation2/04/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description":"field 245 punctuation",
+  "enabled": true,
+  "fix": false,
+  "only": false
+}

--- a/test-fixtures/punctuation2/04/record.json
+++ b/test-fixtures/punctuation2/04/record.json
@@ -1,0 +1,22 @@
+{
+  "leader": "01331cam a22003494i 4500",
+  "fields": [
+    { "tag": "245", "ind1": "1", "ind2": "0", "subfields": [
+        { "code": "a", "value": "Manun illallinen" },
+        { "code": "c", "value": "Tellervo Koivisto" }
+      ]
+    },
+    {
+      "tag": "245", "ind1": "1", "ind2": "0",
+      "subfields": [
+        { "code": "a", "value": "Manun illallinen" },
+        { "code": "b", "value": "lentopallosta hiustöyhtöön" },
+        { "code": "c", "value": "Tellervo Koivisto" }
+      ]
+    },
+    { "tag": "245", "ind1": "1", "ind2": "0", "subfields": [
+      { "code": "a", "value": "OK-otsikko /" },
+      { "code": "c", "value": "Tekijä." }
+    ]}
+  ]
+}

--- a/test-fixtures/punctuation2/05/expectedResult.json
+++ b/test-fixtures/punctuation2/05/expectedResult.json
@@ -1,0 +1,6 @@
+{
+  "message": [
+    "'300 1  ‡a 740 sivua ‡b kuvitettu ‡c 25 cm ‡e 1 CD-levy' => '300 1  ‡a 740 sivua : ‡b kuvitettu ; ‡c 25 cm + ‡e 1 CD-levy'"
+  ],
+  "valid": false
+}

--- a/test-fixtures/punctuation2/05/metadata.json
+++ b/test-fixtures/punctuation2/05/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description":"05: punc 300",
+  "enabled": true,
+  "fix": false,
+  "only": false
+}

--- a/test-fixtures/punctuation2/05/record.json
+++ b/test-fixtures/punctuation2/05/record.json
@@ -1,0 +1,12 @@
+{
+  "leader": "01331cam a22003494i 4500",
+  "fields": [
+    { "tag": "300", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "740 sivua" },
+      { "code": "b", "value": "kuvitettu" },
+      { "code": "c", "value": "25 cm" },
+      { "code": "e", "value": "1 CD-levy" }
+    ]}
+ 
+  ]
+}

--- a/test-fixtures/punctuation2/98/expectedResult.json
+++ b/test-fixtures/punctuation2/98/expectedResult.json
@@ -1,0 +1,39 @@
+{
+  "_validationOptions": {},
+  "leader": "01331cam a22003494i 4500",
+  "fields": [
+    { "tag": "001", "value": "000000001" },
+    { "tag": "041", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "fin" } ] },
+
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+        { "code": "a", "value": "Tuisku, Sara," },
+        { "code": "e", "value": "turkulainen," },
+        { "code": "e", "value": "testaaja." }
+      ]
+    },
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+        { "code": "a", "value": "Reipas, R.," },
+        { "code": "d", "value": "2000-" },
+        { "code": "e", "value": "esittäjä." }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Reippaahko, R.," },
+      { "code": "d", "value": "2000-" }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Reippaampi, R.," },
+      { "code": "d", "value": "2000-2050," },
+      { "code": "e", "value": "esittäjä." }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Reippain, R.," },
+      { "code": "d", "value": "2000-2050." }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Nalle, P.," },
+      { "code": "d", "value": "1926-" },
+      { "code": "0", "value": "(FIN11)000000000"}
+    ]}
+  ]
+
+}

--- a/test-fixtures/punctuation2/98/metadata.json
+++ b/test-fixtures/punctuation2/98/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description":"validate 01 - fix punctuation of X00 fields. Non-X00 fields are fine",
+  "enabled": true,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/punctuation2/98/record.json
+++ b/test-fixtures/punctuation2/98/record.json
@@ -1,0 +1,37 @@
+{
+  "leader": "01331cam a22003494i 4500",
+  "fields": [
+    { "tag": "001", "value": "000000001" },
+    { "tag": "041", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "fin" } ] },
+
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+        { "code": "a", "value": "Tuisku, Sara" },
+        { "code": "e", "value": "turkulainen" },
+        { "code": "e", "value": "testaaja" }
+      ]
+    },
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+        { "code": "a", "value": "Reipas, R." },
+        { "code": "d", "value": "2000-" },
+        { "code": "e", "value": "esittäjä" }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Reippaahko, R." },
+      { "code": "d", "value": "2000-" }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Reippaampi, R." },
+      { "code": "d", "value": "2000-2050" },
+      { "code": "e", "value": "esittäjä" }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Reippain, R." },
+      { "code": "d", "value": "2000-2050" }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Nalle, P." },
+      { "code": "d", "value": "1926-" },
+      { "code": "0", "value": "(FIN11)000000000"}
+    ]}
+  ]
+}

--- a/test-fixtures/punctuation2/99/expectedResult.json
+++ b/test-fixtures/punctuation2/99/expectedResult.json
@@ -1,0 +1,15 @@
+{
+  "_validationOptions": {},
+  "leader": "01331cam a22003494i 4500",
+  "fields": [
+    { "tag": "100", "ind1": "1", "ind2": "0", "subfields": [
+        { "code": "a", "value": "Sukunimi, Etunimi," },
+        { "code": "e", "value": "säveltäjä." }
+      ]
+    },
+    { "tag": "245", "ind1": "1", "ind2": "0", "subfields": [
+      { "code": "a", "value": "Only valid fields in this test /" },
+      { "code": "c", "value": "Tekijä." }
+    ]}
+  ]
+}

--- a/test-fixtures/punctuation2/99/metadata.json
+++ b/test-fixtures/punctuation2/99/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description":"Only fixer test, as fixer always returns true",
+  "enabled": true,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/punctuation2/99/record.json
+++ b/test-fixtures/punctuation2/99/record.json
@@ -1,0 +1,14 @@
+{
+  "leader": "01331cam a22003494i 4500",
+  "fields": [
+    { "tag": "100", "ind1": "1", "ind2": "0", "subfields": [
+        { "code": "a", "value": "Sukunimi, Etunimi," },
+        { "code": "e", "value": "säveltäjä." }
+      ]
+    },
+    { "tag": "245", "ind1": "1", "ind2": "0", "subfields": [
+      { "code": "a", "value": "Only valid fields in this test /" },
+      { "code": "c", "value": "Tekijä." }
+    ]}
+  ]
+}

--- a/test-fixtures/remove-duplicate-datafields/f03/expectedResult.json
+++ b/test-fixtures/remove-duplicate-datafields/f03/expectedResult.json
@@ -1,0 +1,20 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01" },
+      { "code": "8", "value": "1.1\\x" },
+      { "code": "a", "value": "eka"}
+    ]},
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "8", "value": "1.2\\x" },
+      { "code": "a", "value": "toka"}
+    ]},
+
+    { "tag": "880", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "6", "value": "520-01" },
+      { "code": "a", "value": "ake akot"}
+    ]}
+  ],
+  "leader": ""
+}

--- a/test-fixtures/remove-duplicate-datafields/f03/metadata.json
+++ b/test-fixtures/remove-duplicate-datafields/f03/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "Fix-03: remove 520$8 chain + 880",
+  "enabled": true,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/remove-duplicate-datafields/f03/record.json
+++ b/test-fixtures/remove-duplicate-datafields/f03/record.json
@@ -1,0 +1,33 @@
+{
+  "fields": [
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01" },
+      { "code": "8", "value": "1.1\\x" },
+      { "code": "a", "value": "eka"}
+    ]},
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "8", "value": "1.2\\x" },
+      { "code": "a", "value": "toka"}
+    ]},
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-02" },
+      { "code": "8", "value": "2.1\\x" },
+      { "code": "a", "value": "eka"}
+    ]},
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "8", "value": "2.2\\x" },
+      { "code": "a", "value": "toka"}
+    ]},
+
+    { "tag": "880", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "6", "value": "520-01" },
+      { "code": "a", "value": "ake akot"}
+    ]},
+
+    { "tag": "880", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "6", "value": "520-02" },
+      { "code": "a", "value": "ake akot"}
+    ]}
+
+  ]
+}

--- a/test-fixtures/remove-duplicate-datafields/f03b/expectedResult.json
+++ b/test-fixtures/remove-duplicate-datafields/f03b/expectedResult.json
@@ -1,0 +1,20 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01" },
+      { "code": "a", "value": "eka toka"}
+    ]},
+
+    { "tag": "880", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "6", "value": "520-01" },
+      { "code": "8", "value": "1.1\\x" },
+      { "code": "a", "value": "ake"}
+    ]},
+    { "tag": "880", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "8", "value": "1.2\\x" },
+      { "code": "a", "value": "akot"}
+    ]}
+  ],
+  "leader": ""
+}

--- a/test-fixtures/remove-duplicate-datafields/f03b/metadata.json
+++ b/test-fixtures/remove-duplicate-datafields/f03b/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "Fix-03b: handle 520-880 where 880 is $8 chain",
+  "enabled": true,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/remove-duplicate-datafields/f03b/record.json
+++ b/test-fixtures/remove-duplicate-datafields/f03b/record.json
@@ -1,0 +1,35 @@
+{
+  "fields": [
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01" },
+      { "code": "a", "value": "eka toka"}
+    ]},
+
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-02" },
+      { "code": "a", "value": "eka toka"}
+    ]},
+
+    { "tag": "880", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "6", "value": "520-01" },
+      { "code": "8", "value": "1.1\\x" },
+      { "code": "a", "value": "ake"}
+    ]},
+    { "tag": "880", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "8", "value": "1.2\\x" },
+      { "code": "a", "value": "akot"}
+    ]},
+
+    { "tag": "880", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "6", "value": "520-02" },
+      { "code": "8", "value": "2.1\\x" },
+      { "code": "a", "value": "ake"}
+    ]},
+    { "tag": "880", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "8", "value": "2.2\\x" },
+      { "code": "a", "value": "akot"}
+    ]}
+
+
+  ]
+}

--- a/test-fixtures/remove-duplicate-datafields/f03c/expectedResult.json
+++ b/test-fixtures/remove-duplicate-datafields/f03c/expectedResult.json
@@ -1,0 +1,25 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01" },
+      { "code": "8", "value": "1.1\\x" },
+      { "code": "a", "value": "eka"}
+    ]},
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "8", "value": "1.2\\x" },
+      { "code": "a", "value": "toka"}
+    ]},
+
+    { "tag": "880", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "6", "value": "520-01" },
+      { "code": "8", "value": "3.1\\x" },
+      { "code": "a", "value": "ake"}
+    ]},
+    { "tag": "880", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "8", "value": "3.2\\x" },
+      { "code": "a", "value": "akot"}
+    ]}
+  ],
+  "leader": ""
+}

--- a/test-fixtures/remove-duplicate-datafields/f03c/metadata.json
+++ b/test-fixtures/remove-duplicate-datafields/f03c/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "Fix-03c: remove 520$8 chain + 880$8 chains. Too complicated for now.",
+  "enabled": false,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/remove-duplicate-datafields/f03c/record.json
+++ b/test-fixtures/remove-duplicate-datafields/f03c/record.json
@@ -1,0 +1,43 @@
+{
+  "fields": [
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01" },
+      { "code": "8", "value": "1.1\\x" },
+      { "code": "a", "value": "eka"}
+    ]},
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "8", "value": "1.2\\x" },
+      { "code": "a", "value": "toka"}
+    ]},
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-02" },
+      { "code": "8", "value": "2.1\\x" },
+      { "code": "a", "value": "eka"}
+    ]},
+    { "tag": "520", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "8", "value": "2.2\\x" },
+      { "code": "a", "value": "toka"}
+    ]},
+
+    { "tag": "880", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "6", "value": "520-01" },
+      { "code": "8", "value": "3.1\\x" },
+      { "code": "a", "value": "ake"}
+    ]},
+    { "tag": "880", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "8", "value": "3.2\\x" },
+      { "code": "a", "value": "akot"}
+    ]},
+
+    { "tag": "880", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "6", "value": "520-02" },
+      { "code": "8", "value": "4.1\\x" },
+      { "code": "a", "value": "ake"}
+    ]},
+    { "tag": "880", "ind1": "3", "ind2": " ", "subfields": [
+      { "code": "8", "value": "4.2\\x" },
+      { "code": "a", "value": "akot"}
+    ]}
+
+  ]
+}

--- a/test-fixtures/remove-duplicate-datafields/f06/expectedResult.json
+++ b/test-fixtures/remove-duplicate-datafields/f06/expectedResult.json
@@ -6,10 +6,6 @@
       { "code": "6", "value": "880-01" },
       { "code": "a", "value": "Abstrakti. Blah Blah..." }
     ]},
-    { "tag": "520", "ind1": " ", "ind2": " ", "subfields": [
-      { "code": "6", "value": "880-02" },
-      { "code": "a", "value": "Abstrakti. Blah Blah..." }
-    ]},
     { "tag": "880", "ind1": " ", "ind2": " ", "subfields": [
       { "code": "6", "value": "520-01" },
       { "code": "8", "value": "1.1\\x" },
@@ -21,20 +17,6 @@
     ]},
     { "tag": "880", "ind1": " ", "ind2": " ", "subfields": [
       { "code": "8", "value": "1.3\\x" },
-      { "code": "a", "value": "... page3, the end"}
-    ]},
-    
-    { "tag": "880", "ind1": " ", "ind2": " ", "subfields": [
-      { "code": "6", "value": "520-02" },
-      { "code": "8", "value": "2.1\\x" },
-      { "code": "a", "value": "Abstract, page1..."}
-    ]},
-    { "tag": "880", "ind1": " ", "ind2": " ", "subfields": [
-      { "code": "8", "value": "2.2\\x" },
-      { "code": "a", "value": "... continued, page2..."}
-    ]},
-    { "tag": "880", "ind1": " ", "ind2": " ", "subfields": [
-      { "code": "8", "value": "2.3\\x" },
       { "code": "a", "value": "... page3, the end"}
     ]}
   ],

--- a/test-fixtures/remove-duplicate-datafields/v02/expectedResult.json
+++ b/test-fixtures/remove-duplicate-datafields/v02/expectedResult.json
@@ -4,9 +4,7 @@
     "700 1  ‡a A., A., ‡e kirjoittaja, ‡e taiteilija.",
     "700 1  ‡a B., B., ‡e kirjoittaja.",
     "700 1  ‡6 880-01 ‡a C., C., ‡e kirjoittaja.",
-    "880 1  ‡6 700-02 ‡a D., D., ‡e kirjoittaja.",
-    "700 1  ‡6 880-XX ‡a C., C., ‡e kirjoittaja.\t__SEPARATOR__\t700 1  ‡6 880-XX ‡a C., C., ‡e kirjoittaja.",
-    "880 1  ‡6 X00-XX ‡a D., D., ‡e kirjoittaja.\t__SEPARATOR__\t880 1  ‡6 X00-XX ‡a D., D., ‡e kirjoittaja."
+    "880 1  ‡6 700-02 ‡a D., D., ‡e kirjoittaja."
   ],
   "valid": false
 }

--- a/test-fixtures/remove-duplicate-datafields/v03/expectedResult.json
+++ b/test-fixtures/remove-duplicate-datafields/v03/expectedResult.json
@@ -1,7 +1,6 @@
 {
   "message": [
-    "100 1  ‡6 880-01 ‡a Zabara, Olena, ‡e kirjoittaja, ‡e taiteilija.",
-    "100 1  ‡6 880-XX ‡a Zabara, Olena, ‡e kirjoittaja, ‡e taiteilija.\t__SEPARATOR__\t100 1  ‡6 880-XX ‡a Zabara, Olena, ‡e kirjoittaja, ‡e taiteilija.\t__SEPARATOR__\t880 1  ‡6 X00-XX/(N ‡a Забара, Олена, ‡e kirjoittaja, ‡e taiteilija."
+    "100 1  ‡6 880-01 ‡a Zabara, Olena, ‡e kirjoittaja, ‡e taiteilija."
   ],
   "valid": false
 }

--- a/test-fixtures/remove-inferior-datafields/f01/expectedResult.json
+++ b/test-fixtures/remove-inferior-datafields/f01/expectedResult.json
@@ -1,0 +1,21 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "653", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "term"},
+        { "code": "9", "value": "FENNI<KEEP>"}
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Sukunimi, Etunimi,"},
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Sukunimi, Etunimi,"},
+      { "code": "e", "value": "taiteilija." }
+    ]}
+
+  ],
+  "leader": ""
+}

--- a/test-fixtures/remove-inferior-datafields/f01/metadata.json
+++ b/test-fixtures/remove-inferior-datafields/f01/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "f01: removable subsets deleted",
+  "enabled": true,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/remove-inferior-datafields/f01/record.json
+++ b/test-fixtures/remove-inferior-datafields/f01/record.json
@@ -1,0 +1,31 @@
+{
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "653", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "term"} ]},
+    { "tag": "653", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "term"},
+        { "code": "9", "value": "FENNI<KEEP>"}
+    ]},
+
+
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Sukunimi, Etunimi,"},
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Sukunimi, Etunimi,"},
+      { "code": "e", "value": "kirjoittaja." }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Sukunimi, Etunimi,"},
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Sukunimi, Etunimi." }
+    ]}
+
+
+  ],
+  "leader": ""
+}

--- a/test-fixtures/remove-inferior-datafields/v01/expectedResult.json
+++ b/test-fixtures/remove-inferior-datafields/v01/expectedResult.json
@@ -1,0 +1,6 @@
+{
+  "message": [
+
+  ],
+  "valid": true
+}

--- a/test-fixtures/remove-inferior-datafields/v01/metadata.json
+++ b/test-fixtures/remove-inferior-datafields/v01/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "v01: no deletable fields detected",
+  "enabled": true,
+  "fix": false,
+  "only": false
+}

--- a/test-fixtures/remove-inferior-datafields/v01/record.json
+++ b/test-fixtures/remove-inferior-datafields/v01/record.json
@@ -1,0 +1,31 @@
+{
+  "fields": [
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01" },
+      { "code": "a", "value": "Zabara, Olena,"},
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "600", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-02" },
+      { "code": "a", "value": "FOO"},
+      { "code": "e", "value": "whatever" }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "500-00/(N" },
+      { "code": "a", "value": "Lorum ipsum." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "100-01/(N" },
+      { "code": "a", "value": "Забара, Олена," },
+      { "code": "e", "value": "kirjoittaja," },
+      { "code": "e", "value": "taiteilija." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "600-02" },
+      { "code": "a", "value": "BAR"},
+      { "code": "e", "value": "whatever" }
+    ]}
+
+  ]
+}


### PR DESCRIPTION
* Add validators
** punctuation2 - contains punctuation functionality used in https://github.com/NatLibFi/melinda-marc-record-merge-reducers-js
** removeInferiorDataFields - contains functionality to remove almost identical field duplicates

* Updates to removeDuplicateDataFields -validator ** Support $6+$8 chains. Tune $6 chain rules.

* Update dependencies
* Update isbn3 version

* Update melinda-test-node GitHubActions workflow

* v10.3.0-alpha.1