### PR TITLE
Nv20230609

### DIFF
--- a/src/punctuation2.js
+++ b/src/punctuation2.js
@@ -3,7 +3,8 @@
 *
 * Author(s): Nicholas Volk <nicholas.volk@helsinki.fi>
 *
-* NOTE #1: https://www.kiwi.fi/display/kumea/Loppupisteohje is implemented via another validator/fixer.(ending-punctuation)
+* NOTE #1: https://www.kiwi.fi/display/kumea/Loppupisteohje is implemented via another validator/fixer (ending-punctuation).
+*          This file has some support but it's now yet thorough. (And mmight never be.)
 * NOTE #2: Validator/fixer punctuation does similar stuff, but focuses on X00 fields.
 * NOTE #3: As of 2023-06-05 control subfields ($0...$9) are obsolete. Don't use them in rules.
 *          (They are jumped over when looking for next (non-controlfield subfield)
@@ -54,7 +55,7 @@ function getNextRelevantSubfield(field, currSubfieldIndex) {
   return field.subfields.find((subfield, index) => index > currSubfieldIndex && !isControlSubfield(subfield));
 }
 
-function fieldGetFixedString(field, add = true) {
+export function fieldGetFixedString(field, add = true) {
   const cloneField = clone(field);
   const operation = add ? subfieldFixPunctuation : subfieldStripPunctuation;
   cloneField.subfields.forEach((sf, i) => {
@@ -65,7 +66,7 @@ function fieldGetFixedString(field, add = true) {
   return fieldToString(cloneField);
 }
 
-function fieldNeedsModification(field, add = true) {
+export function fieldNeedsModification(field, add = true) {
   if (!field.subfields) {
     return false;
   }
@@ -141,14 +142,16 @@ const cleanCrappyPunctuationRules = {
   '710': removeX10Whatever,
   '800': removeX00Whatever,
   '810': removeX10Whatever,
-  '245': [{'code': 'ab', 'followedBy': '!c', 'remove': / \/$/u}],
+  '245': [
+    {'code': 'ab', 'followedBy': '!c', 'remove': / \/$/u},
+    {'code': 'abc', 'followedBy': '#', 'remove': /\.$/u, 'context': dotIsProbablyPunc}
+  ],
   '300': [
     {'code': 'a', 'followedBy': '!b', 'remove': / *:$/u},
     {'code': 'a', 'followedBy': 'b', 'remove': /:$/u, 'context': /[^ ]:$/u},
     {'code': 'ab', 'followedBy': '!c', 'remove': / *;$/u},
     {'code': 'ab', 'followedBy': 'c', 'remove': /;$/u, 'context': /[^ ];$/u},
-    {'code': 'abc', 'followedBy': '!e', 'remove': / *\+$/u},
-    {'code': 'abc', 'followedBy': '!e', 'remove': / *\+$/u, 'context': /[^ ]\+$/u}
+    {'code': 'abc', 'followedBy': '!e', 'remove': / *\+$/u} // Removes both valid (with one space) and invalid (spaceless et al) puncs
 
   ],
   '490': [{'code': 'a', 'followedBy': 'xy', 'remove': / ;$/u}],
@@ -228,7 +231,8 @@ const addPairedPunctuationRules = {
     // Blah! Also "$a = $b" and "$a ; $b" can be valid... But ' :' is better than nothing, I guess...
     {'code': 'a', 'followedBy': 'b', 'add': ' :', 'context': defaultNeedsPuncAfter},
     {'code': 'abk', 'followedBy': 'f', 'add': ',', 'context': defaultNeedsPuncAfter},
-    {'code': 'abfnp', 'followedBy': 'c', 'add': ' /', 'context': defaultNeedsPuncAfter}
+    {'code': 'abfnp', 'followedBy': 'c', 'add': ' /', 'context': defaultNeedsPuncAfter},
+    {'code': 'abc', 'followedBy': '#', 'add': '.', 'context': defaultNeedsPuncAfter} // Stepping on punctuation/ toes
   ],
   '260': [
     {'code': 'a', 'followedBy': 'b', 'add': ' :', 'context': defaultNeedsPuncAfter2},

--- a/src/removeInferiorDataFields.js
+++ b/src/removeInferiorDataFields.js
@@ -199,6 +199,11 @@ function deriveIndividualDeletables(record) {
         tmp = tmp.replace(/( ‡6 [0-9][0-9][0-9])-[0-9]+/, '$1-00');
         nvdebug(`MET-381: ADD TO DELETABLES: ${tmp}`);
         deletableStringsArray.push(tmp);
+        if (tmp.match(/ ‡6 [0-9][0-9][0-9]-00\/[^ ]+ /)) {
+          tmp = tmp.replace(/( ‡6 [0-9][0-9][0-9]-00)[^ ]+/, '$1');
+          nvdebug(`MET-381: ADD TO DELETABLES: ${tmp}`);
+          deletableStringsArray.push(tmp);
+        }
       }
     }
 

--- a/src/stripPunctuation.js
+++ b/src/stripPunctuation.js
@@ -1,0 +1,42 @@
+/*
+* stripPunctuation.js -- try and remove a marc field punctuation (based on and reverse of punctuation2.js)
+*
+* Author(s): Nicholas Volk <nicholas.volk@helsinki.fi>
+*
+*/
+
+import {fieldGetFixedString, fieldNeedsModification, fieldStripPunctuation} from './punctuation2';
+// import createDebugLogger from 'debug';
+import {fieldToString, nvdebug} from './utils';
+
+// const debug = createDebugLogger('@natlibfi/marc-record-validators-melinda/punctuation2');
+
+export default function () {
+  return {
+    description: 'Strip punctuation to data fields',
+    validate, fix
+  };
+
+  function fix(record) {
+    nvdebug('Strip punctuation to data fields: fixer');
+    const res = {message: [], fix: [], valid: true};
+    record.fields.forEach(f => fieldStripPunctuation(f));
+    return res;
+  }
+
+  function validate(record) {
+    nvdebug('Strip punctuation to data fields: validate');
+
+    const fieldsNeedingModification = record.fields.filter(f => fieldNeedsModification(f, false));
+
+    const values = fieldsNeedingModification.map(f => fieldToString(f));
+    const newValues = fieldsNeedingModification.map(f => fieldGetFixedString(f, false));
+
+    const messages = values.map((val, i) => `'${val}' => '${newValues[i]}'`);
+
+    const res = {message: messages};
+
+    res.valid = res.message.length < 1; // eslint-disable-line functional/immutable-data
+    return res;
+  }
+}

--- a/src/stripPunctuation.spec.js
+++ b/src/stripPunctuation.spec.js
@@ -1,0 +1,52 @@
+import {expect} from 'chai';
+import {MarcRecord} from '@natlibfi/marc-record';
+import validatorFactory from './stripPunctuation';
+import {READERS} from '@natlibfi/fixura';
+import generateTests from '@natlibfi/fixugen';
+import createDebugLogger from 'debug';
+
+generateTests({
+  callback,
+  path: [__dirname, '..', 'test-fixtures', 'strip-punctuation'],
+  useMetadataFile: true,
+  recurse: false,
+  fixura: {
+    reader: READERS.JSON
+  },
+  mocha: {
+    before: () => testValidatorFactory()
+  }
+});
+const debug = createDebugLogger('@natlibfi/marc-record-validators-melinda/stripPunctuation:test');
+
+async function testValidatorFactory() {
+  const validator = await validatorFactory();
+
+  expect(validator)
+    .to.be.an('object')
+    .that.has.any.keys('description', 'validate');
+
+  expect(validator.description).to.be.a('string');
+  expect(validator.validate).to.be.a('function');
+}
+
+async function callback({getFixture, enabled = true, fix = false}) {
+  if (enabled === false) {
+    debug('TEST SKIPPED!');
+    return;
+  }
+
+  const validator = await validatorFactory();
+  const record = new MarcRecord(getFixture('record.json'));
+  const expectedResult = getFixture('expectedResult.json');
+  // console.log(expectedResult); // eslint-disable-line
+
+  if (!fix) {
+    const result = await validator.validate(record);
+    expect(result).to.eql(expectedResult);
+    return;
+  }
+
+  await validator.fix(record);
+  expect(record).to.eql(expectedResult);
+}

--- a/src/subfield6Utils.js
+++ b/src/subfield6Utils.js
@@ -114,7 +114,8 @@ export function intToOccurrenceNumberString(i) {
   return i < 10 ? `0${i}` : `${i}`;
 }
 
-function fieldGetMaxSubfield6OccurrenceNumberAsInteger(field) {
+export function fieldGetMaxSubfield6OccurrenceNumberAsInteger(field) {
+  // used by reducer!
   //nvdebug(`Checking subfields $6 from ${JSON.stringify(field)}`);
   const sf6s = field.subfields ? field.subfields.filter(subfield => isValidSubfield6(subfield)) : [];
   if (sf6s.length === 0) {

--- a/test-fixtures/punctuation2/04/expectedResult.json
+++ b/test-fixtures/punctuation2/04/expectedResult.json
@@ -1,7 +1,7 @@
 {
   "message": [
-    "'245 10 ‡a Manun illallinen ‡c Tellervo Koivisto' => '245 10 ‡a Manun illallinen / ‡c Tellervo Koivisto'",
-    "'245 10 ‡a Manun illallinen ‡b lentopallosta hiustöyhtöön ‡c Tellervo Koivisto' => '245 10 ‡a Manun illallinen : ‡b lentopallosta hiustöyhtöön / ‡c Tellervo Koivisto'"
+    "'245 10 ‡a Manun illallinen ‡c Tellervo Koivisto' => '245 10 ‡a Manun illallinen / ‡c Tellervo Koivisto.'",
+    "'245 10 ‡a Manun illallinen ‡b lentopallosta hiustöyhtöön ‡c Tellervo Koivisto' => '245 10 ‡a Manun illallinen : ‡b lentopallosta hiustöyhtöön / ‡c Tellervo Koivisto.'"
   ],
   "valid": false
 }

--- a/test-fixtures/remove-inferior-datafields/f03/metadata.json
+++ b/test-fixtures/remove-inferior-datafields/f03/metadata.json
@@ -1,6 +1,5 @@
 {
-  "description": "f03: removable subset chains deleted",
-  "comment": "2023-06-10: included MET-423 into this test",
+  "description": "f03: removable subset chains deleted + MET-423 is deleted",
   "enabled": true,
   "fix": true,
   "only": false

--- a/test-fixtures/remove-inferior-datafields/f03/metadata.json
+++ b/test-fixtures/remove-inferior-datafields/f03/metadata.json
@@ -1,5 +1,6 @@
 {
   "description": "f03: removable subset chains deleted",
+  "comment": "2023-06-10: included MET-423 into this test",
   "enabled": true,
   "fix": true,
   "only": false

--- a/test-fixtures/remove-inferior-datafields/f03/record.json
+++ b/test-fixtures/remove-inferior-datafields/f03/record.json
@@ -10,6 +10,10 @@
       { "code": "a", "value": "foo"}
     ]},
     { "tag": "880", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "6", "value": "500-00"},
+      { "code": "a", "value": "bar"}
+    ]},
+    { "tag": "880", "ind1": " ", "ind2": " ", "subfields": [
       { "code": "6", "value": "500-01"},
       { "code": "a", "value": "bar"}
     ]},

--- a/test-fixtures/strip-punctuation/01/expectedResult.json
+++ b/test-fixtures/strip-punctuation/01/expectedResult.json
@@ -1,0 +1,12 @@
+{
+  "message": [
+    "'100 1  ‡a Tuisku, Sara, ‡e turkulainen, ‡e testaaja.' => '100 1  ‡a Tuisku, Sara ‡e turkulainen ‡e testaaja'",
+    "'700 1  ‡a Reipas, R., ‡d 2000- ‡e esittäjä.' => '700 1  ‡a Reipas, R. ‡d 2000- ‡e esittäjä'",
+    "'700 1  ‡a Reippaahko, R., ‡d 2000-' => '700 1  ‡a Reippaahko, R. ‡d 2000-'",
+    "'700 1  ‡a Reippaampi, R., ‡d 2000-2050, ‡e esittäjä.' => '700 1  ‡a Reippaampi, R. ‡d 2000-2050 ‡e esittäjä'",
+    "'700 1  ‡a Reippain, R., ‡d 2000-2050.' => '700 1  ‡a Reippain, R. ‡d 2000-2050'",
+    "'700 1  ‡a Nalle, P., ‡d 1926- ‡0 (FIN11)000000000' => '700 1  ‡a Nalle, P. ‡d 1926- ‡0 (FIN11)000000000'"
+  ],
+  "valid": false
+
+}

--- a/test-fixtures/strip-punctuation/01/metadata.json
+++ b/test-fixtures/strip-punctuation/01/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description":"validate 01 - fix punctuation of X00 fields. Non-X00 fields are fine",
+  "enabled": true,
+  "fix": false,
+  "only": false
+}

--- a/test-fixtures/strip-punctuation/01/record.json
+++ b/test-fixtures/strip-punctuation/01/record.json
@@ -1,0 +1,37 @@
+{
+  "leader": "01331cam a22003494i 4500",
+  "fields": [
+    { "tag": "001", "value": "000000001" },
+    { "tag": "041", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "fin" } ] },
+
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+        { "code": "a", "value": "Tuisku, Sara," },
+        { "code": "e", "value": "turkulainen," },
+        { "code": "e", "value": "testaaja." }
+      ]
+    },
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+        { "code": "a", "value": "Reipas, R.," },
+        { "code": "d", "value": "2000-" },
+        { "code": "e", "value": "esittäjä." }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Reippaahko, R.," },
+      { "code": "d", "value": "2000-" }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Reippaampi, R.," },
+      { "code": "d", "value": "2000-2050," },
+      { "code": "e", "value": "esittäjä." }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Reippain, R.," },
+      { "code": "d", "value": "2000-2050." }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Nalle, P.," },
+      { "code": "d", "value": "1926-" },
+      { "code": "0", "value": "(FIN11)000000000"}
+    ]}
+  ]
+}

--- a/test-fixtures/strip-punctuation/02/expectedResult.json
+++ b/test-fixtures/strip-punctuation/02/expectedResult.json
@@ -1,0 +1,4 @@
+{
+  "message": [],
+  "valid": true
+}

--- a/test-fixtures/strip-punctuation/02/metadata.json
+++ b/test-fixtures/strip-punctuation/02/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description":"field 245 non-punctuation test",
+  "enabled": true,
+  "fix": false,
+  "only": false
+}

--- a/test-fixtures/strip-punctuation/02/record.json
+++ b/test-fixtures/strip-punctuation/02/record.json
@@ -1,0 +1,14 @@
+{
+  "leader": "01331cam a22003494i 4500",
+  "fields": [
+    { "tag": "100", "ind1": "1", "ind2": "0", "subfields": [
+        { "code": "a", "value": "Sukunimi, Etunimi" },
+        { "code": "e", "value": "säveltäjä" }
+      ]
+    },
+    { "tag": "245", "ind1": "1", "ind2": "0", "subfields": [
+      { "code": "a", "value": "Only already stripped fields in this test" },
+      { "code": "c", "value": "Tekijä" }
+    ]}
+  ]
+}

--- a/test-fixtures/strip-punctuation/04/expectedResult.json
+++ b/test-fixtures/strip-punctuation/04/expectedResult.json
@@ -1,0 +1,6 @@
+{
+  "message": [
+    "'245 10 ‡a OK-otsikko / ‡c Tekijä.' => '245 10 ‡a OK-otsikko ‡c Tekijä'"
+   ],
+  "valid": false
+}

--- a/test-fixtures/strip-punctuation/04/metadata.json
+++ b/test-fixtures/strip-punctuation/04/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description":"field 245 both non-punc and punc fields: pick some",
+  "enabled": true,
+  "fix": false,
+  "only": false
+}

--- a/test-fixtures/strip-punctuation/04/record.json
+++ b/test-fixtures/strip-punctuation/04/record.json
@@ -1,0 +1,22 @@
+{
+  "leader": "01331cam a22003494i 4500",
+  "fields": [
+    { "tag": "245", "ind1": "1", "ind2": "0", "subfields": [
+        { "code": "a", "value": "Manun illallinen" },
+        { "code": "c", "value": "Tellervo Koivisto" }
+      ]
+    },
+    {
+      "tag": "245", "ind1": "1", "ind2": "0",
+      "subfields": [
+        { "code": "a", "value": "Manun illallinen" },
+        { "code": "b", "value": "lentopallosta hiustöyhtöön" },
+        { "code": "c", "value": "Tellervo Koivisto" }
+      ]
+    },
+    { "tag": "245", "ind1": "1", "ind2": "0", "subfields": [
+      { "code": "a", "value": "OK-otsikko /" },
+      { "code": "c", "value": "Tekijä." }
+    ]}
+  ]
+}

--- a/test-fixtures/strip-punctuation/05/expectedResult.json
+++ b/test-fixtures/strip-punctuation/05/expectedResult.json
@@ -1,0 +1,6 @@
+{
+  "message": [
+    "'300 1  ‡a 740 sivua : ‡b kuvitettu ; ‡c 25 cm + ‡e 1 CD-levy' => '300 1  ‡a 740 sivua ‡b kuvitettu ‡c 25 cm ‡e 1 CD-levy'"
+  ],
+  "valid": false
+}

--- a/test-fixtures/strip-punctuation/05/metadata.json
+++ b/test-fixtures/strip-punctuation/05/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description":"05: punc 300",
+  "enabled": true,
+  "fix": false,
+  "only": false
+}

--- a/test-fixtures/strip-punctuation/05/record.json
+++ b/test-fixtures/strip-punctuation/05/record.json
@@ -1,0 +1,12 @@
+{
+  "leader": "01331cam a22003494i 4500",
+  "fields": [
+    { "tag": "300", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "740 sivua :" },
+      { "code": "b", "value": "kuvitettu ;" },
+      { "code": "c", "value": "25 cm +" },
+      { "code": "e", "value": "1 CD-levy" }
+    ]}
+ 
+  ]
+}

--- a/test-fixtures/strip-punctuation/98/expectedResult.json
+++ b/test-fixtures/strip-punctuation/98/expectedResult.json
@@ -1,0 +1,44 @@
+{
+  "_validationOptions": {},
+  "leader": "01331cam a22003494i 4500",
+  "fields": [
+    { "tag": "001", "value": "000000001" },
+    { "tag": "041", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "fin" } ] },
+
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+        { "code": "a", "value": "Tuisku, Sara" },
+        { "code": "e", "value": "turkulainen" },
+        { "code": "e", "value": "testaaja" }
+      ]
+    },
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+        { "code": "a", "value": "Reipas, R." },
+        { "code": "d", "value": "2000-" },
+        { "code": "e", "value": "esittäjä" }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Reippaahko, R." },
+      { "code": "d", "value": "2000-" }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Reippaampi, R." },
+      { "code": "d", "value": "2000-2050" },
+      { "code": "e", "value": "esittäjä" }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Reippain, R." },
+      { "code": "d", "value": "2000-2050" }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Nalle, P." },
+      { "code": "d", "value": "1926-" },
+      { "code": "0", "value": "(FIN11)000000000"}
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Aasi, Ihaa" },
+      { "code": "d", "value": "2000-2050" },
+      { "code": "0", "value": "(FIN11)000000000"},
+      { "code": "e", "value": "käsikirjoittaja"}
+    ]}
+  ]
+}

--- a/test-fixtures/strip-punctuation/98/metadata.json
+++ b/test-fixtures/strip-punctuation/98/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description":"Fix 98 - fix punctuation of X00 fields. Non-X00 fields are fine",
+  "enabled": true,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/strip-punctuation/98/record.json
+++ b/test-fixtures/strip-punctuation/98/record.json
@@ -1,0 +1,45 @@
+{
+  "_validationOptions": {},
+  "leader": "01331cam a22003494i 4500",
+  "fields": [
+    { "tag": "001", "value": "000000001" },
+    { "tag": "041", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "fin" } ] },
+
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+        { "code": "a", "value": "Tuisku, Sara," },
+        { "code": "e", "value": "turkulainen," },
+        { "code": "e", "value": "testaaja." }
+      ]
+    },
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+        { "code": "a", "value": "Reipas, R.," },
+        { "code": "d", "value": "2000-" },
+        { "code": "e", "value": "esittäjä." }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Reippaahko, R.," },
+      { "code": "d", "value": "2000-" }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Reippaampi, R.," },
+      { "code": "d", "value": "2000-2050," },
+      { "code": "e", "value": "esittäjä." }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Reippain, R.," },
+      { "code": "d", "value": "2000-2050." }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Nalle, P.," },
+      { "code": "d", "value": "1926-" },
+      { "code": "0", "value": "(FIN11)000000000"}
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Aasi, Ihaa," },
+      { "code": "d", "value": "2000-2050," },
+      { "code": "0", "value": "(FIN11)000000000"},
+      { "code": "e", "value": "käsikirjoittaja."}
+    ]}
+  ]
+
+}

--- a/test-fixtures/strip-punctuation/99/expectedResult.json
+++ b/test-fixtures/strip-punctuation/99/expectedResult.json
@@ -1,0 +1,16 @@
+{
+  "_validationOptions": {},
+  "leader": "01331cam a22003494i 4500",
+  "fields": [
+    { "tag": "100", "ind1": "1", "ind2": "0", "subfields": [
+        { "code": "a", "value": "Sukunimi, Etunimi" },
+        { "code": "e", "value": "säveltäjä" },
+        { "code": "e", "value": "koheltaja" }
+      ]
+    },
+    { "tag": "245", "ind1": "1", "ind2": "0", "subfields": [
+      { "code": "a", "value": "Only valid fields in this test" },
+      { "code": "c", "value": "Tekijä" }
+    ]}
+  ]
+}

--- a/test-fixtures/strip-punctuation/99/metadata.json
+++ b/test-fixtures/strip-punctuation/99/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description":"Only fixer test, as fixer always returns true",
+  "enabled": true,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/strip-punctuation/99/record.json
+++ b/test-fixtures/strip-punctuation/99/record.json
@@ -1,0 +1,16 @@
+{
+  "_validationOptions": {},
+  "leader": "01331cam a22003494i 4500",
+  "fields": [
+    { "tag": "100", "ind1": "1", "ind2": "0", "subfields": [
+        { "code": "a", "value": "Sukunimi, Etunimi," },
+        { "code": "e", "value": "säveltäjä," },
+        { "code": "e", "value": "koheltaja." }
+      ]
+    },
+    { "tag": "245", "ind1": "1", "ind2": "0", "subfields": [
+      { "code": "a", "value": "Only valid fields in this test /" },
+      { "code": "c", "value": "Tekijä." }
+    ]}
+  ]
+}


### PR DESCRIPTION
- New validator/fixer for removing punctuation (stripPunctuation.js)
- Fix MET-431 (duplicate X00$e), a bug that was introduced in recent $0...$9 skipping code: modification to punctuation stripping
- MET-423-ish ghost removal (the actual fix for MET-423 is done in reducer in a completely different way though)