### PR TITLE
New validator + some tuning to old ones

### DIFF
--- a/src/punctuation2.js
+++ b/src/punctuation2.js
@@ -120,7 +120,7 @@ const addLanguageComma = {'name': 'Add comma before 810$l', 'add': ',', 'code': 
 const addColonToRelationshipInformation = {'name': 'Add \':\' to 7X0 $i relationship info', 'add': ':', 'code': 'i', 'context': /[a-z)åäö]$/u};
 
 // 490:
-const addSemicolonBeforeVolumeDesignation = {'name': 'Add " ;" before $v', 'add': ' ;', 'code': 'atxy', 'followedBy': 'v', 'context': /[^;]$/u};
+const addSemicolonBeforeVolumeDesignation = {'name': 'Add " ;" before $v', 'add': ' ;', 'code': 'atxyz', 'followedBy': 'v', 'context': /[^;]$/u};
 
 const NONE = 0;
 const ADD = 2;
@@ -133,15 +133,13 @@ const REMOVE_AND_ADD = 3;
 const removeX00Whatever = [removeX00Comma, cleanX00aDot, cleanX00eDot, cleanCorruption, cleanX00dCommaOrDot, cleanRHS, X00RemoveDotAfterBracket, removeColons, cleanPuncBeforeLanguage];
 const removeX10Whatever = [removeX00Comma, cleanX00aDot, cleanX00eDot, cleanCorruption, removeColons, cleanPuncBeforeLanguage];
 
+const remove490And830Whatever = [{'code': 'axyzv', 'followedBy': 'axyzv', 'remove': /(?: *;| *=|,)$/u}];
+
+const linkingEntryWhatever = [{'code': 'abdghiklmnopqrstuwxyz', 'followedBy': 'abdghiklmnopqrstuwxyz', 'remove': /\. -$/u}];
+
 const cleanCrappyPunctuationRules = {
   '100': removeX00Whatever,
   '110': removeX10Whatever,
-  '600': removeX00Whatever,
-  '610': removeX10Whatever,
-  '700': removeX00Whatever,
-  '710': removeX10Whatever,
-  '800': removeX00Whatever,
-  '810': removeX10Whatever,
   '245': [
     {'code': 'ab', 'followedBy': '!c', 'remove': / \/$/u},
     {'code': 'abc', 'followedBy': '#', 'remove': /\.$/u, 'context': dotIsProbablyPunc}
@@ -154,8 +152,18 @@ const cleanCrappyPunctuationRules = {
     {'code': 'abc', 'followedBy': '!e', 'remove': / *\+$/u} // Removes both valid (with one space) and invalid (spaceless et al) puncs
 
   ],
-  '490': [{'code': 'a', 'followedBy': 'xy', 'remove': / ;$/u}],
-  '773': [{'code': 'abdghiklmnopqrstuwxyz', 'followedBy': 'abdghiklmnopqrstuwxyz', 'remove': /\. -$/u}]
+
+  '490': remove490And830Whatever,
+  '600': removeX00Whatever,
+  '610': removeX10Whatever,
+  '700': removeX00Whatever,
+  '710': removeX10Whatever,
+  '773': linkingEntryWhatever,
+  '774': linkingEntryWhatever,
+  '776': linkingEntryWhatever,
+  '800': removeX00Whatever,
+  '810': removeX10Whatever,
+  '830': remove490And830Whatever
 
 };
 
@@ -172,6 +180,12 @@ const cleanLegalX10Comma = {'name': 'X10comma', 'code': 'abe', 'followedBy': 'e'
 const cleanLegalX10Dot = {'name': 'X10dot', 'code': 'ab', 'followedBy': 'b#', 'context': /.\.$/u, 'remove': /\.$/u};
 
 const legalX10punc = [cleanLegalX10Comma, cleanLegalX10Dot, cleanX00eDot, cleanLanguageComma];
+
+const cleanLegalSeriesTitle = [ // 490 and 830
+  {'code': 'a', 'followedBy': 'a', 'remove': / =$/u},
+  {'code': 'axyz', 'followedBy': 'xyz', 'remove': /,$/u, 'context': /.,$/u},
+  {'code': 'axyz', 'followedBy': 'v', 'remove': / *;$/u}
+];
 
 const cleanValidPunctuationRules = {
   '100': legalX00punc,
@@ -198,7 +212,7 @@ const cleanValidPunctuationRules = {
     {'code': 'c', 'followedBy': '#', 'remove': /\.$/u},
     {'code': 'd', 'followedBy': 'e', 'remove': / :$/u},
     {'code': 'e', 'followedBy': 'f', 'remove': /,$/u},
-    {'code': 'f', 'followedBy': '#', 'remove': /\.$/u} // Probably ')' but shouldit be removed?
+    {'code': 'f', 'followedBy': '#', 'remove': /\.$/u} // Probably ')' but should it be removed?
   ],
   '264': [
     {'code': 'a', 'followedBy': 'b', 'remove': / :$/u},
@@ -211,19 +225,24 @@ const cleanValidPunctuationRules = {
     {'code': 'ab', 'followedBy': 'c', 'remove': / ;$/u},
     {'code': 'abc', 'followedBy': 'e', 'remove': / \+$/u}
   ],
-  '490': [
-    {'code': 'axy', 'followedBy': 'xy', 'remove': /,$/u},
-    {'code': 'axy', 'followedBy': 'v', 'remove': / *;$/u}
-  ],
+  '490': cleanLegalSeriesTitle,
   '534': [{'code': 'p', 'followedBy': 'c', 'remove': /:$/u}],
   // Experimental, MET366-ish (end punc in internationally valid, but we don't use it here in Finland):
-  '648': [{'code': 'a', 'content': /^[0-9]+\.$/u, 'ind2': ['4'], 'remove': /\.$/u}]
+  '648': [{'code': 'a', 'content': /^[0-9]+\.$/u, 'ind2': ['4'], 'remove': /\.$/u}],
+  '830': cleanLegalSeriesTitle
 
 };
 
 // addColonToRelationshipInformation only applies to 700/710 but as others don't have $i, it's fine
 const addX00 = [addX00aComma, addX00aComma2, addX00aDot, addLanguageComma, addSemicolonBeforeVolumeDesignation, addColonToRelationshipInformation];
 const addX10 = [addX10bDot, addX10eComma, addX10Dot, addLanguageComma, addSemicolonBeforeVolumeDesignation, addColonToRelationshipInformation];
+
+const addSeriesTitle = [ // 490 and 830
+  {'code': 'a', 'followedBy': 'a', 'add': ' =', 'context': defaultNeedsPuncAfter2},
+  {'code': 'axyz', 'followedBy': 'xy', 'add': ',', 'context': defaultNeedsPuncAfter},
+  addSemicolonBeforeVolumeDesignation //  eg. 490$axyz-$v
+];
+
 const addPairedPunctuationRules = {
   '100': addX00,
   '110': addX10,
@@ -253,11 +272,7 @@ const addPairedPunctuationRules = {
     {'code': 'ab', 'followedBy': 'c', 'add': ' ;', 'context': defaultNeedsPuncAfter2},
     {'code': 'abc', 'followedBy': 'e', 'add': ' +', 'context': defaultNeedsPuncAfter2}
   ],
-  '490': [
-    {'code': 'axy', 'followedBy': 'xy', 'add': ',', 'context': defaultNeedsPuncAfter},
-    addSemicolonBeforeVolumeDesignation
-    //{'code': 'axy', 'followedBy': 'v', 'add': ' ;', 'context': defaultNeedsPuncAfter}
-  ],
+  '490': addSeriesTitle,
   '506': [{'code': 'a', 'followedBy': '#', 'add': '.', 'context': defaultNeedsPuncAfter2}],
   '534': [{'code': 'p', 'followedBy': 'c', 'add': ':', 'context': defaultNeedsPuncAfter2}],
   '600': addX00,
@@ -266,12 +281,7 @@ const addPairedPunctuationRules = {
   '710': addX10,
   '800': addX00,
   '810': addX10,
-  '830': [
-    {'code': 'axy', 'followedBy': 'xy', 'add': ',', 'context': defaultNeedsPuncAfter},
-    addSemicolonBeforeVolumeDesignation
-    //{'code': 'axy', 'followedBy': 'v', 'add': ' ;', 'context': defaultNeedsPuncAfter}
-  ]
-
+  '830': addSeriesTitle
 };
 
 

--- a/src/removeInferiorDataFields.js
+++ b/src/removeInferiorDataFields.js
@@ -195,7 +195,7 @@ function deriveIndividualDeletables(record) {
     // MET-381: remove occurence number TAG-00, if TAG-NN existists
     if (field.tag === '880') {
       tmp = fieldAsString;
-      if (tmp.match(/ ‡6 [0-9][0-9][0-9]-([?:1-9][0-9]|0[1-9])/)) {
+      if (tmp.match(/ ‡6 [0-9][0-9][0-9]-(?:[1-9][0-9]|0[1-9])/)) {
         tmp = tmp.replace(/( ‡6 [0-9][0-9][0-9])-[0-9]+/, '$1-00');
         nvdebug(`MET-381: ADD TO DELETABLES: ${tmp}`);
         deletableStringsArray.push(tmp);

--- a/src/subfieldValueNormalizations.js
+++ b/src/subfieldValueNormalizations.js
@@ -1,0 +1,85 @@
+//import createDebugLogger from 'debug';
+import clone from 'clone';
+import {fieldToString} from './utils';
+
+// Note that https://github.com/NatLibFi/marc-record-validators-melinda/blob/master/src/unicode-decomposition.js contains
+// similar functionalities. It's less generic and lacks diacritic removal but has it advantages as well.
+
+//const debug = createDebugLogger('@natlibfi/marc-record-validators-melinda/normalize-utf-diacritics');
+
+// See also https://github.com/NatLibFi/marc-record-validators-melinda/blob/master/src/unicode-decomposition.js .
+// It uses a list of convertable characters whilst this uses a generic stuff as well.
+// It handles various '.' and '©' type normalizations as well.
+// NB! This version has minor bug/feature issue regarding fixComposition()
+
+// Author(s): Nicholas Volk
+export default function () {
+
+  return {
+    description: 'Fix various subfield internal values',
+    validate, fix
+  };
+
+  function fix(record) {
+    const res = {message: [], fix: [], valid: true};
+
+    record.fields.forEach(field => {
+      normalizeSubfieldValues(field);
+    });
+
+    // message.valid = !(message.message.length >= 1); // eslint-disable-line functional/immutable-data
+    return res;
+  }
+
+  function validate(record) {
+    const res = {message: []};
+
+    record.fields.forEach(field => {
+      validateField(field, res);
+    });
+
+    res.valid = !(res.message.length >= 1); // eslint-disable-line functional/immutable-data
+    return res;
+  }
+
+  function validateField(field, res) {
+    if (!field.subfields) {
+      return;
+    }
+    const orig = fieldToString(field);
+
+    const normalizedField = normalizeSubfieldValues(clone(field));
+    const mod = fieldToString(normalizedField);
+    if (orig !== mod) { // Fail as the input is "broken"/"crap"/sumthing
+      res.message.push(`'${orig}' requires subfield internal mods/normalization`); // eslint-disable-line functional/immutable-data
+      return;
+    }
+    return;
+  }
+}
+
+function getNormalizedValue(subfield, field) {
+  if (field.ind1 === '1' && subfield.code === 'a' && ['100', '600', '700', '800'].includes(field.tag)) {
+    // Fix MRA-267/273 (partial):
+    // Proof-of-concept: Handle the most common case(s). (And extend them rules later on if the need arises):
+    if (field.subfields.every(sf => sf.code !== '0')) {
+      return subfield.value.replace(/, ([A-Z]|Å|Ö|Ö)\.([A-Z]|Å|Ö|Ö)\.(,?)$/u, ', $1. $2.$3'); // eslint-disable-line prefer-named-capture-group
+    }
+  }
+
+  if (subfield.code === 'a' && ['130', '630', '730'].includes(field.tag)) {
+    // MRA-614: "(elokuva, 2000)" => "(elokuva : 2000)""
+    return subfield.value.replace(/\((elokuva), (19[0-9][0-9]|20[0-2][0-9])\)/u, '($1 : $2)'); // eslint-disable-line prefer-named-capture-group
+  }
+  return subfield.value;
+}
+
+function normalizeSubfieldValues(field) {
+  if (!field.subfields) {
+    return field;
+  }
+  field.subfields.forEach((subfield, index) => {
+    field.subfields[index].value = getNormalizedValue(subfield, field); // eslint-disable-line functional/immutable-data
+  });
+  return field;
+}

--- a/src/subfieldValueNormalizations.spec.js
+++ b/src/subfieldValueNormalizations.spec.js
@@ -1,0 +1,52 @@
+import {expect} from 'chai';
+import {MarcRecord} from '@natlibfi/marc-record';
+import validatorFactory from './subfieldValueNormalizations';
+import {READERS} from '@natlibfi/fixura';
+import generateTests from '@natlibfi/fixugen';
+import createDebugLogger from 'debug';
+
+generateTests({
+  callback,
+  path: [__dirname, '..', 'test-fixtures', 'normalize-subfield-value'],
+  useMetadataFile: true,
+  recurse: false,
+  fixura: {
+    reader: READERS.JSON
+  },
+  mocha: {
+    before: () => testValidatorFactory()
+  }
+});
+const debug = createDebugLogger('@natlibfi/marc-record-validators-melinda/subfieldValueNormalizations:test');
+
+async function testValidatorFactory() {
+  const validator = await validatorFactory();
+
+  expect(validator)
+    .to.be.an('object')
+    .that.has.any.keys('description', 'validate');
+
+  expect(validator.description).to.be.a('string');
+  expect(validator.validate).to.be.a('function');
+}
+
+async function callback({getFixture, enabled = true, fix = false}) {
+  if (enabled === false) {
+    debug('TEST SKIPPED!');
+    return;
+  }
+
+  const validator = await validatorFactory();
+  const record = new MarcRecord(getFixture('record.json'));
+  const expectedResult = getFixture('expectedResult.json');
+  // console.log(expectedResult); // eslint-disable-line
+
+  if (!fix) {
+    const result = await validator.validate(record);
+    expect(result).to.eql(expectedResult);
+    return;
+  }
+
+  await validator.fix(record);
+  expect(record).to.eql(expectedResult);
+}

--- a/test-fixtures/normalize-subfield-value/01/expectedResult.json
+++ b/test-fixtures/normalize-subfield-value/01/expectedResult.json
@@ -1,0 +1,8 @@
+{
+  "message": [
+    "'100 1# ‡a Sukunimi, A.B., ‡e kirjoittaja.' requires subfield internal mods/normalization",
+    "'700 1# ‡a Sukunimelä, A.B.' requires subfield internal mods/normalization",
+    "'730 ## ‡a Movie (elokuva, 2020)' requires subfield internal mods/normalization"
+  ],
+  "valid": false
+}

--- a/test-fixtures/normalize-subfield-value/01/metadata.json
+++ b/test-fixtures/normalize-subfield-value/01/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "Validate subfield internal normalization: fail, since probablematic fields",
+  "comment": "Related issues: MRA-273, MRA-614...",
+  "enabled": true,
+  "fix": false
+}

--- a/test-fixtures/normalize-subfield-value/01/record.json
+++ b/test-fixtures/normalize-subfield-value/01/record.json
@@ -1,0 +1,31 @@
+{
+  "fields": [
+    { "tag": "005", "value": "20220202020202.0" },
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+        { "code": "a", "value": "Sukunimi, A.B.," },
+        { "code": "e", "value": "kirjoittaja." }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Auktorisoitu-Nimi, A.B.," },
+      { "code": "e", "value": "kirjoittaja." },
+      { "code": "0", "value": "(FI-ASTERI-N)007654321"}
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Sukunimi, A.B.C.," },
+      { "code": "e", "value": "kirjoittaja." }
+      ]
+    },
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Sukunimelä, A.B." }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Sukunimelä, A.B.C." }
+      ]
+    },
+    { "tag": "730", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Movie (elokuva, 2020)" }
+      ]
+    }
+
+  ]
+}

--- a/test-fixtures/normalize-subfield-value/02/expectedResult.json
+++ b/test-fixtures/normalize-subfield-value/02/expectedResult.json
@@ -1,0 +1,32 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "005", "value": "20220202020202.0" },
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+        { "code": "a", "value": "Sukunimi, A. B.," },
+        { "code": "e", "value": "kirjoittaja." }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Auktorisoitu-Nimi, A.B.," },
+      { "code": "e", "value": "kirjoittaja." },
+      { "code": "0", "value": "(FI-ASTERI-N)007654321"}
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Sukunimi, A.B.C.," },
+      { "code": "e", "value": "kirjoittaja." }
+      ]
+    },
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Sukunimelä, A. B." }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Sukunimelä, A.B.C." }
+      ]
+    },
+    { "tag": "730", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Movie (elokuva : 2020)" }
+      ]
+    }
+  ],
+  "leader": ""
+}

--- a/test-fixtures/normalize-subfield-value/02/metadata.json
+++ b/test-fixtures/normalize-subfield-value/02/metadata.json
@@ -1,0 +1,5 @@
+{
+  "description": "Apply subfield internal normalization: fail, since probablematic fields",
+  "comment": "Related issues: MRA-273, MRA-614...",
+  "fix": true
+}

--- a/test-fixtures/normalize-subfield-value/02/record.json
+++ b/test-fixtures/normalize-subfield-value/02/record.json
@@ -1,0 +1,31 @@
+{
+  "fields": [
+    { "tag": "005", "value": "20220202020202.0" },
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+        { "code": "a", "value": "Sukunimi, A.B.," },
+        { "code": "e", "value": "kirjoittaja." }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Auktorisoitu-Nimi, A.B.," },
+      { "code": "e", "value": "kirjoittaja." },
+      { "code": "0", "value": "(FI-ASTERI-N)007654321"}
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Sukunimi, A.B.C.," },
+      { "code": "e", "value": "kirjoittaja." }
+      ]
+    },
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Sukunimelä, A.B." }
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Sukunimelä, A.B.C." }
+      ]
+    },
+    { "tag": "730", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Movie (elokuva, 2020)" }
+      ]
+    }
+
+  ]
+}

--- a/test-fixtures/punctuation2/97/expectedResult.json
+++ b/test-fixtures/punctuation2/97/expectedResult.json
@@ -1,0 +1,21 @@
+{
+  "_validationOptions": {},
+  "leader": "01331cam a22003494i 4500",
+  "fields": [
+    { "tag": "001", "value": "000000001" },
+    { "tag": "041", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "fin" } ] },
+
+    { "tag": "490", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "Suomeksi =" },
+        { "code": "a", "value": "Ruotsiksi," },
+        { "code": "x", "value": "1234-5678 ;" },
+        { "code": "v", "value": "4" }
+      ]},
+    { "tag": "830", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Suomeksi =" },
+      { "code": "a", "value": "Ruotsiksi," },
+      { "code": "x", "value": "1234-5678 ;" },
+      { "code": "v", "value": "4" }
+    ]}
+  ]
+}

--- a/test-fixtures/punctuation2/97/metadata.json
+++ b/test-fixtures/punctuation2/97/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description":"Fix 97 - fix punctuation of 490 and 830",
+  "enabled": true,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/punctuation2/97/record.json
+++ b/test-fixtures/punctuation2/97/record.json
@@ -1,0 +1,20 @@
+{
+  "leader": "01331cam a22003494i 4500",
+  "fields": [
+    { "tag": "001", "value": "000000001" },
+    { "tag": "041", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "fin" } ] },
+
+    { "tag": "490", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "Suomeksi" },
+        { "code": "a", "value": "Ruotsiksi" },
+        { "code": "x", "value": "1234-5678" },
+        { "code": "v", "value": "4" }
+      ]},
+    { "tag": "830", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Suomeksi" },
+      { "code": "a", "value": "Ruotsiksi" },
+      { "code": "x", "value": "1234-5678" },
+      { "code": "v", "value": "4" }
+    ]}
+  ]
+}

--- a/test-fixtures/strip-punctuation/97/expectedResult.json
+++ b/test-fixtures/strip-punctuation/97/expectedResult.json
@@ -1,0 +1,21 @@
+{
+  "_validationOptions": {},
+  "leader": "01331cam a22003494i 4500",
+  "fields": [
+    { "tag": "001", "value": "000000001" },
+    { "tag": "041", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "fin" } ] },
+
+    { "tag": "490", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "Suomeksi" },
+        { "code": "a", "value": "Ruotsiksi" },
+        { "code": "x", "value": "1234-5678" },
+        { "code": "v", "value": "4" }
+      ]},
+    { "tag": "830", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Suomeksi" },
+      { "code": "a", "value": "Ruotsiksi" },
+      { "code": "x", "value": "1234-5678" },
+      { "code": "v", "value": "4" }
+    ]}
+  ]
+}

--- a/test-fixtures/strip-punctuation/97/metadata.json
+++ b/test-fixtures/strip-punctuation/97/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description":"Fix 97 - fix punctuation of 490 and 830",
+  "enabled": true,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/strip-punctuation/97/record.json
+++ b/test-fixtures/strip-punctuation/97/record.json
@@ -1,0 +1,20 @@
+{
+  "leader": "01331cam a22003494i 4500",
+  "fields": [
+    { "tag": "001", "value": "000000001" },
+    { "tag": "041", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "fin" } ] },
+
+    { "tag": "490", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "Suomeksi =" },
+        { "code": "a", "value": "Ruotsiksi," },
+        { "code": "x", "value": "1234-5678 ;" },
+        { "code": "v", "value": "4" }
+      ]},
+    { "tag": "830", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Suomeksi =" },
+      { "code": "a", "value": "Ruotsiksi," },
+      { "code": "x", "value": "1234-5678 ;" },
+      { "code": "v", "value": "4" }
+    ]}
+  ]
+}


### PR DESCRIPTION
- Proper punctuation rules for field 490 and 830 (paving way for MRA-483 fix) + tests
- New validator/fixer subfieldValueNormalizations.js that currently handles MRA-273 (partial) and MRA-614 +test
- Minor regexp fix in removeInferiorDataFields.js