### PR TITLE
MRA-613

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@natlibfi/marc-record-validators-melinda",
-  "version": "10.10.0",
+  "version": "10.11.0-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@natlibfi/marc-record-validators-melinda",
-      "version": "10.10.0",
+      "version": "10.11.0-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@babel/register": "^7.22.5",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "git@github.com:natlibfi/marc-record-validators-melinda.git"
   },
   "license": "MIT",
-  "version": "10.10.0",
+  "version": "10.11.0-alpha.1",
   "main": "./dist/index.js",
   "publishConfig": {
     "access": "public"

--- a/src/sync-007-and-300.js
+++ b/src/sync-007-and-300.js
@@ -1,0 +1,127 @@
+//import createDebugLogger from 'debug';
+import {fieldToString} from './utils';
+import clone from 'clone';
+
+//const debug = createDebugLogger('@natlibfi/marc-record-validators-melinda/sanitize-vocabulary-source-codes);
+
+// Author(s): Nicholas Volk, Joni Ollila
+export default function () {
+
+  return {
+    description: 'Validator for sanitizing vocabulary source codes in subfield $2 (MRA-532)',
+    validate, fix
+  };
+
+  function fix(record) {
+    const res = {message: [], fix: [], valid: true};
+    record.fields.forEach(f => fixField(f, record));
+    return res;
+  }
+
+  function validate(record) {
+    const res = {message: []};
+
+    record.fields.forEach(field => {
+      validateField(field, res, record);
+    });
+
+    res.valid = !(res.message.length >= 1); // eslint-disable-line functional/immutable-data
+    return res;
+  }
+
+  function validateField(field, res, record) {
+    if (field.tag !== '007') {
+      return;
+    }
+    const orig = fieldToString(field);
+
+    const normalizedField = fixField(clone(field), record);
+    const mod = fieldToString(normalizedField);
+    if (orig !== mod) { // Fail as the input is "broken"/"crap"/sumthing
+      res.message.push(`FIXABLE: '${orig}' => '${mod}'`); // eslint-disable-line functional/immutable-data
+      return;
+    }
+
+    /*
+    if (fieldHasUnfixableStuff(field)) {
+      res.message.push(`CAN'T BE FIXED AUTOMATICALLY: '${orig}'`); // eslint-disable-line functional/immutable-data
+      return;
+    }
+    */
+    return;
+  }
+
+  function fieldIsBluray007(field) {
+    if (field.tag !== '007') {
+      return false;
+    }
+    return field.value.match(/^v...s/u);
+  }
+
+  function fieldIsDvd007(field) {
+    if (field.tag !== '007') {
+      return false;
+    }
+    return field.value.match(/^v...v/u);
+  }
+
+  function fieldIsBluray300(field) {
+    if (field.tag !== '300') {
+      return false;
+    }
+    return field.subfields.some(subfield => subfield.value.match(/(?:Blu.?ray|BD)/ui));
+  }
+
+  function fieldIsDvd300(field) {
+    if (field.tag !== '300') {
+      return false;
+    }
+    return field.subfields.some(subfield => subfield.value.match(/DVD/ui));
+  }
+
+  function recordHasBluray300(record) {
+    return record.fields.some(f => fieldIsBluray300(f));
+  }
+
+  function recordHasDvd300(record) {
+    return record.fields.some(f => fieldIsDvd300(f));
+  }
+
+  function convert007BlurayToDvd(field) {
+    if (!fieldIsBluray007(field)) {
+      return;
+    }
+    //field.value = field.value.substring(0, 4) + 's' + field.value.substring(5); // eslint-disable-line functional/immutable-data
+    //field.value = field.value.replace(/^(?:v...)s/u, `${1}v`); // eslint-disable-line functional/immutable-data, no-template-curly-in-string
+    field.value = `${field.value.substring(0, 4)}v${field.value.substring(5)}`; // eslint-disable-line functional/immutable-data
+  }
+
+  function convert007DvdToBluray(field) {
+    if (!fieldIsDvd007(field)) {
+      return;
+    }
+    //field.value = field.value.replace(/^(?:v...)v/u, `${1}s`); // eslint-disable-line functional/immutable-data
+    field.value = `${field.value.substring(0, 4)}s${field.value.substring(5)}`; // eslint-disable-line functional/immutable-data
+  }
+
+  function fixField(field, record) {
+    if (field.tag !== '007') {
+      return field;
+    }
+
+    if (fieldIsDvd007(field) && recordHasBluray300(record) && !recordHasDvd300(record)) {
+      // FIX 007: DVD -> Blu-ray
+      convert007DvdToBluray(field);
+      return field;
+    }
+
+    if (fieldIsBluray007(field) && recordHasDvd300(record) && !recordHasBluray300(record)) {
+      // FIX 007: Blu-Ray -> DVD
+      convert007BlurayToDvd(field);
+      return field;
+    }
+
+    return field;
+  }
+
+}

--- a/src/sync-007-and-300.js
+++ b/src/sync-007-and-300.js
@@ -8,7 +8,7 @@ import clone from 'clone';
 export default function () {
 
   return {
-    description: 'Validator for sanitizing vocabulary source codes in subfield $2 (MRA-532)',
+    description: 'Validator for updating mismatching f007 based on f300 (DVD/Bluray) (MRA-613)',
     validate, fix
   };
 

--- a/src/sync-007-and-300.spec.js
+++ b/src/sync-007-and-300.spec.js
@@ -1,0 +1,52 @@
+import {expect} from 'chai';
+import {MarcRecord} from '@natlibfi/marc-record';
+import validatorFactory from './sync-007-and-300';
+import {READERS} from '@natlibfi/fixura';
+import generateTests from '@natlibfi/fixugen';
+import createDebugLogger from 'debug';
+
+generateTests({
+  callback,
+  path: [__dirname, '..', 'test-fixtures', 'sync-007-and-300'],
+  useMetadataFile: true,
+  recurse: false,
+  fixura: {
+    reader: READERS.JSON
+  },
+  mocha: {
+    before: () => testValidatorFactory()
+  }
+});
+const debug = createDebugLogger('@natlibfi/marc-record-validators-melinda/sync-007-and-300:test');
+
+async function testValidatorFactory() {
+  const validator = await validatorFactory();
+
+  expect(validator)
+    .to.be.an('object')
+    .that.has.any.keys('description', 'validate');
+
+  expect(validator.description).to.be.a('string');
+  expect(validator.validate).to.be.a('function');
+}
+
+async function callback({getFixture, enabled = true, fix = false}) {
+  if (enabled === false) {
+    debug('TEST SKIPPED!');
+    return;
+  }
+
+  const validator = await validatorFactory();
+  const record = new MarcRecord(getFixture('record.json'));
+  const expectedResult = getFixture('expectedResult.json');
+  // console.log(expectedResult); // eslint-disable-line
+
+  if (!fix) {
+    const result = await validator.validate(record);
+    expect(result).to.eql(expectedResult);
+    return;
+  }
+
+  await validator.fix(record);
+  expect(record).to.eql(expectedResult);
+}

--- a/test-fixtures/sync-007-and-300/f01/expectedResult.json
+++ b/test-fixtures/sync-007-and-300/f01/expectedResult.json
@@ -1,0 +1,16 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "007", "value": "vd|csaizq" },
+    { "tag": "007", "value": "vd|cs||||" },
+
+    { "tag": "300", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "1 Blu-ray-videolevy (2 h 15 min) :"},
+        { "code": "b", "value": "värillinen, ääni ;"},
+        { "code": "c", "value": "12 cm"}
+    ]}
+
+  ],
+  "leader": ""
+}

--- a/test-fixtures/sync-007-and-300/f01/metadata.json
+++ b/test-fixtures/sync-007-and-300/f01/metadata.json
@@ -1,0 +1,7 @@
+{
+  "description": "f01: Fixable 007 found and fixed",
+  "comment": "Note that the other (blu-ray) 007 is kept as well...",
+  "enabled": true,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/sync-007-and-300/f01/record.json
+++ b/test-fixtures/sync-007-and-300/f01/record.json
@@ -1,0 +1,15 @@
+{
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "007", "value": "vd|csaizq" },
+    { "tag": "007", "value": "vd|cv||||" },
+
+    { "tag": "300", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "1 Blu-ray-videolevy (2 h 15 min) :"},
+        { "code": "b", "value": "värillinen, ääni ;"},
+        { "code": "c", "value": "12 cm"}
+    ]}
+
+  ],
+  "leader": ""
+}

--- a/test-fixtures/sync-007-and-300/v01/expectedResult.json
+++ b/test-fixtures/sync-007-and-300/v01/expectedResult.json
@@ -1,0 +1,6 @@
+{
+  "message": [
+    "FIXABLE: '007    vd|cv||||' => '007    vd|cs||||'"
+  ],
+  "valid": false
+}

--- a/test-fixtures/sync-007-and-300/v01/metadata.json
+++ b/test-fixtures/sync-007-and-300/v01/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "v01: Fixable 007 found",
+  "enabled": true,
+  "fix": false,
+  "only": false
+}

--- a/test-fixtures/sync-007-and-300/v01/record.json
+++ b/test-fixtures/sync-007-and-300/v01/record.json
@@ -1,0 +1,15 @@
+{
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "007", "value": "vd|csaizq" },
+    { "tag": "007", "value": "vd|cv||||" },
+
+    { "tag": "300", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "1 Blu-ray-videolevy (2 h 15 min) :"},
+        { "code": "b", "value": "värillinen, ääni ;"},
+        { "code": "c", "value": "12 cm"}
+    ]}
+
+  ],
+  "leader": ""
+}

--- a/test-fixtures/sync-007-and-300/v02/expectedResult.json
+++ b/test-fixtures/sync-007-and-300/v02/expectedResult.json
@@ -1,0 +1,5 @@
+{
+  "message": [
+  ],
+  "valid": true
+}

--- a/test-fixtures/sync-007-and-300/v02/metadata.json
+++ b/test-fixtures/sync-007-and-300/v02/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "v01: No fixable 007 found",
+  "enabled": true,
+  "fix": false,
+  "only": false
+}

--- a/test-fixtures/sync-007-and-300/v02/record.json
+++ b/test-fixtures/sync-007-and-300/v02/record.json
@@ -1,0 +1,14 @@
+{
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "007", "value": "vd|csaizq" },
+
+    { "tag": "300", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "1 Blu-ray-videolevy (2 h 15 min) :"},
+        { "code": "b", "value": "värillinen, ääni ;"},
+        { "code": "c", "value": "12 cm"}
+    ]}
+
+  ],
+  "leader": ""
+}

--- a/test-fixtures/sync-007-and-300/v03/expectedResult.json
+++ b/test-fixtures/sync-007-and-300/v03/expectedResult.json
@@ -1,0 +1,6 @@
+{
+  "message": [
+    "FIXABLE: '007    vd|csaizq' => '007    vd|cvaizq'"
+  ],
+  "valid": false
+}

--- a/test-fixtures/sync-007-and-300/v03/metadata.json
+++ b/test-fixtures/sync-007-and-300/v03/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "v03: Fixable 007 found",
+  "enabled": true,
+  "fix": false,
+  "only": false
+}

--- a/test-fixtures/sync-007-and-300/v03/record.json
+++ b/test-fixtures/sync-007-and-300/v03/record.json
@@ -1,0 +1,15 @@
+{
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "007", "value": "vd|csaizq" },
+    { "tag": "007", "value": "vd|cv||||" },
+
+    { "tag": "300", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "DVD (2 h 15 min) :"},
+        { "code": "b", "value": "värillinen, ääni ;"},
+        { "code": "c", "value": "12 cm"}
+    ]}
+
+  ],
+  "leader": ""
+}


### PR DESCRIPTION
Jos videon 007/04-merkkipaikan ja 300-kentän välillä on ristiriita, niin validaattori muuttaa 300-kenttien perusteella videon 007/04:n s->v (kun 300=dvd)  ja v->s (kun 300=blu-ray).