### PR TITLE
Nv20230821 (#205)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@natlibfi/marc-record-validators-melinda",
-  "version": "10.11.1",
+  "version": "10.12.0-alpha.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@natlibfi/marc-record-validators-melinda",
-      "version": "10.11.1",
+      "version": "10.12.0-alpha.3",
       "license": "MIT",
       "dependencies": {
         "@babel/register": "^7.22.5",
@@ -117,24 +117,24 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.10.tgz",
-      "integrity": "sha512-fTmqbbUBAwCcre6zPzNngvsI0aNrPZe77AeqvDxWM9Nm+04RrJ3CAmGHA9f7lJQY6ZMhRztNemy4uslDxTX4Qw==",
+      "version": "7.22.11",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.11.tgz",
+      "integrity": "sha512-lh7RJrtPdhibbxndr6/xx0w8+CVlY5FJZiaSz908Fpy+G0xkBFTvwLcKJFF4PJxVfGhVWNebikpWGnOoC71juQ==",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.10",
         "@babel/generator": "^7.22.10",
         "@babel/helper-compilation-targets": "^7.22.10",
         "@babel/helper-module-transforms": "^7.22.9",
-        "@babel/helpers": "^7.22.10",
-        "@babel/parser": "^7.22.10",
+        "@babel/helpers": "^7.22.11",
+        "@babel/parser": "^7.22.11",
         "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.10",
-        "@babel/types": "^7.22.10",
+        "@babel/traverse": "^7.22.11",
+        "@babel/types": "^7.22.11",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.2",
+        "json5": "^2.2.3",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -146,9 +146,9 @@
       }
     },
     "node_modules/@babel/eslint-parser": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.22.10.tgz",
-      "integrity": "sha512-0J8DNPRXQRLeR9rPaUMM3fA+RbixjnVLe/MRMYCkp3hzgsSuxCHQ8NN8xQG1wIHKJ4a1DTROTvFJdW+B5/eOsg==",
+      "version": "7.22.11",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.22.11.tgz",
+      "integrity": "sha512-YjOYZ3j7TjV8OhLW6NCtyg8G04uStATEUe5eiLuCZaXz2VSDQ3dsAtm2D+TuQyAqNMUK2WacGo0/uma9Pein1w==",
       "dev": true,
       "dependencies": {
         "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
@@ -217,9 +217,9 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.22.10.tgz",
-      "integrity": "sha512-5IBb77txKYQPpOEdUdIhBx8VrZyDCQ+H82H0+5dX1TmuscP5vJKEE3cKurjtIw/vFwzbVH48VweE78kVDBrqjA==",
+      "version": "7.22.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.22.11.tgz",
+      "integrity": "sha512-y1grdYL4WzmUDBRGK0pDbIoFd7UZKoDurDzWEoNMYoj1EL+foGRQNyPWDcC+YyegN5y1DUsFFmzjGijB3nSVAQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
@@ -472,13 +472,13 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.10.tgz",
-      "integrity": "sha512-a41J4NW8HyZa1I1vAndrraTlPZ/eZoga2ZgS7fEr0tZJGVU4xqdE80CEm0CcNjha5EZ8fTBYLKHF0kqDUuAwQw==",
+      "version": "7.22.11",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.11.tgz",
+      "integrity": "sha512-vyOXC8PBWaGc5h7GMsNx68OH33cypkEDJCHvYVVgVbbxJDROYVtexSk0gK5iCF1xNjRIN2s8ai7hwkWDq5szWg==",
       "dependencies": {
         "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.10",
-        "@babel/types": "^7.22.10"
+        "@babel/traverse": "^7.22.11",
+        "@babel/types": "^7.22.11"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -498,9 +498,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.10.tgz",
-      "integrity": "sha512-lNbdGsQb9ekfsnjFGhEiF4hfFqGgfOP3H3d27re3n+CGhNuTSUEQdfWk556sTLNTloczcdM5TYF2LhzmDQKyvQ==",
+      "version": "7.22.11",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.11.tgz",
+      "integrity": "sha512-R5zb8eJIBPJriQtbH/htEQy4k7E2dHWlD2Y2VT07JCzwYZHBxV5ZYtM0UhXSNMT74LyxuM+b1jdL7pSesXbC/g==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -803,9 +803,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-async-generator-functions": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.22.10.tgz",
-      "integrity": "sha512-eueE8lvKVzq5wIObKK/7dvoeKJ+xc6TvRn6aysIjS6pSCeLy7S/eVi7pEQknZqyqvzaNKdDtem8nUNTBgDVR2g==",
+      "version": "7.22.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.22.11.tgz",
+      "integrity": "sha512-0pAlmeRJn6wU84zzZsEOx1JV1Jf8fqO9ok7wofIJwUnplYo247dcd24P+cMJht7ts9xkzdtB0EPHmOb7F+KzXw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.5",
@@ -884,12 +884,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-class-static-block": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.22.5.tgz",
-      "integrity": "sha512-SPToJ5eYZLxlnp1UzdARpOGeC2GbHvr9d/UV0EukuVx8atktg194oe+C5BqQ8jRTkgLRVOPYeXRSBg1IlMoVRA==",
+      "version": "7.22.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.22.11.tgz",
+      "integrity": "sha512-GMM8gGmqI7guS/llMFk1bJDkKfn3v3C4KHK9Yg1ey5qcHcOlKb0QvcMrgzvxo+T03/4szNh5lghY+fEC98Kq9g==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.22.5",
+        "@babel/helper-create-class-features-plugin": "^7.22.11",
         "@babel/helper-plugin-utils": "^7.22.5",
         "@babel/plugin-syntax-class-static-block": "^7.14.5"
       },
@@ -986,9 +986,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-dynamic-import": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.22.5.tgz",
-      "integrity": "sha512-0MC3ppTB1AMxd8fXjSrbPa7LT9hrImt+/fcj+Pg5YMD7UQyWp/02+JWpdnCymmsXwIx5Z+sYn1bwCn4ZJNvhqQ==",
+      "version": "7.22.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.22.11.tgz",
+      "integrity": "sha512-g/21plo58sfteWjaO0ZNVb+uEOkJNjAaHhbejrnBmu011l/eNDScmkbjCC3l4FKb10ViaGU4aOkFznSu2zRHgA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -1018,9 +1018,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-export-namespace-from": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.22.5.tgz",
-      "integrity": "sha512-X4hhm7FRnPgd4nDA4b/5V280xCx6oL7Oob5+9qVS5C13Zq4bh1qq7LU0GgRU6b5dBWBvhGaXYVB4AcN6+ol6vg==",
+      "version": "7.22.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.22.11.tgz",
+      "integrity": "sha512-xa7aad7q7OiT8oNZ1mU7NrISjlSkVdMbNxn9IuLZyL9AJEhs1Apba3I+u5riX1dIkdptP5EKDG5XDPByWxtehw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -1066,9 +1066,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-json-strings": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.22.5.tgz",
-      "integrity": "sha512-DuCRB7fu8MyTLbEQd1ew3R85nx/88yMoqo2uPSjevMj3yoN7CDM8jkgrY0wmVxfJZyJ/B9fE1iq7EQppWQmR5A==",
+      "version": "7.22.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.22.11.tgz",
+      "integrity": "sha512-CxT5tCqpA9/jXFlme9xIBCc5RPtdDq3JpkkhgHQqtDdiTnTI0jtZ0QzXhr5DILeYifDPp2wvY2ad+7+hLMW5Pw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -1097,9 +1097,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-logical-assignment-operators": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.22.5.tgz",
-      "integrity": "sha512-MQQOUW1KL8X0cDWfbwYP+TbVbZm16QmQXJQ+vndPtH/BoO0lOKpVoEDMI7+PskYxH+IiE0tS8xZye0qr1lGzSA==",
+      "version": "7.22.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.22.11.tgz",
+      "integrity": "sha512-qQwRTP4+6xFCDV5k7gZBF3C31K34ut0tbEcTKxlX/0KXxm9GLcO14p570aWxFvVzx6QAfPgq7gaeIHXJC8LswQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -1144,12 +1144,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.22.5.tgz",
-      "integrity": "sha512-B4pzOXj+ONRmuaQTg05b3y/4DuFz3WcCNAXPLb2Q0GT0TrGKGxNKV4jwsXts+StaM0LQczZbOpj8o1DLPDJIiA==",
+      "version": "7.22.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.22.11.tgz",
+      "integrity": "sha512-o2+bg7GDS60cJMgz9jWqRUsWkMzLCxp+jFDeDUT5sjRlAxcJWZ2ylNdI7QQ2+CH5hWu7OnN+Cv3htt7AkSf96g==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.22.5",
+        "@babel/helper-module-transforms": "^7.22.9",
         "@babel/helper-plugin-utils": "^7.22.5",
         "@babel/helper-simple-access": "^7.22.5"
       },
@@ -1161,13 +1161,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.22.5.tgz",
-      "integrity": "sha512-emtEpoaTMsOs6Tzz+nbmcePl6AKVtS1yC4YNAeMun9U8YCsgadPNxnOPQ8GhHFB2qdx+LZu9LgoC0Lthuu05DQ==",
+      "version": "7.22.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.22.11.tgz",
+      "integrity": "sha512-rIqHmHoMEOhI3VkVf5jQ15l539KrwhzqcBO6wdCNWPWc/JWt9ILNYNUssbRpeq0qWns8svuw8LnMNCvWBIJ8wA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-hoist-variables": "^7.22.5",
-        "@babel/helper-module-transforms": "^7.22.5",
+        "@babel/helper-module-transforms": "^7.22.9",
         "@babel/helper-plugin-utils": "^7.22.5",
         "@babel/helper-validator-identifier": "^7.22.5"
       },
@@ -1226,9 +1226,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.22.5.tgz",
-      "integrity": "sha512-6CF8g6z1dNYZ/VXok5uYkkBBICHZPiGEl7oDnAx2Mt1hlHVHOSIKWJaXHjQJA5VB43KZnXZDIexMchY4y2PGdA==",
+      "version": "7.22.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.22.11.tgz",
+      "integrity": "sha512-YZWOw4HxXrotb5xsjMJUDlLgcDXSfO9eCmdl1bgW4+/lAGdkjaEvOnQ4p5WKKdUgSzO39dgPl0pTnfxm0OAXcg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -1242,9 +1242,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-numeric-separator": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.22.5.tgz",
-      "integrity": "sha512-NbslED1/6M+sXiwwtcAB/nieypGw02Ejf4KtDeMkCEpP6gWFMX1wI9WKYua+4oBneCCEmulOkRpwywypVZzs/g==",
+      "version": "7.22.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.22.11.tgz",
+      "integrity": "sha512-3dzU4QGPsILdJbASKhF/V2TVP+gJya1PsueQCxIPCEcerqF21oEcrob4mzjsp2Py/1nLfF5m+xYNMDpmA8vffg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -1258,13 +1258,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-object-rest-spread": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.22.5.tgz",
-      "integrity": "sha512-Kk3lyDmEslH9DnvCDA1s1kkd3YWQITiBOHngOtDL9Pt6BZjzqb6hiOlb8VfjiiQJ2unmegBqZu0rx5RxJb5vmQ==",
+      "version": "7.22.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.22.11.tgz",
+      "integrity": "sha512-nX8cPFa6+UmbepISvlf5jhQyaC7ASs/7UxHmMkuJ/k5xSHvDPPaibMo+v3TXwU/Pjqhep/nFNpd3zn4YR59pnw==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.22.5",
-        "@babel/helper-compilation-targets": "^7.22.5",
+        "@babel/compat-data": "^7.22.9",
+        "@babel/helper-compilation-targets": "^7.22.10",
         "@babel/helper-plugin-utils": "^7.22.5",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
         "@babel/plugin-transform-parameters": "^7.22.5"
@@ -1293,9 +1293,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-optional-catch-binding": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.22.5.tgz",
-      "integrity": "sha512-pH8orJahy+hzZje5b8e2QIlBWQvGpelS76C63Z+jhZKsmzfNaPQ+LaW6dcJ9bxTpo1mtXbgHwy765Ro3jftmUg==",
+      "version": "7.22.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.22.11.tgz",
+      "integrity": "sha512-rli0WxesXUeCJnMYhzAglEjLWVDF6ahb45HuprcmQuLidBJFWjNnOzssk2kuc6e33FlLaiZhG/kUIzUMWdBKaQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -1309,9 +1309,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-optional-chaining": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.22.10.tgz",
-      "integrity": "sha512-MMkQqZAZ+MGj+jGTG3OTuhKeBpNcO+0oCEbrGNEaOmiEn+1MzRyQlYsruGiU8RTK3zV6XwrVJTmwiDOyYK6J9g==",
+      "version": "7.22.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.22.11.tgz",
+      "integrity": "sha512-7X2vGqH2ZKu7Imx0C+o5OysRwtF/wzdCAqmcD1N1v2Ww8CtOSC+p+VoV76skm47DLvBZ8kBFic+egqxM9S/p4g==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -1357,13 +1357,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-private-property-in-object": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.22.5.tgz",
-      "integrity": "sha512-/9xnaTTJcVoBtSSmrVyhtSvO3kbqS2ODoh2juEU72c3aYonNF0OMGiaz2gjukyKM2wBBYJP38S4JiE0Wfb5VMQ==",
+      "version": "7.22.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.22.11.tgz",
+      "integrity": "sha512-sSCbqZDBKHetvjSwpyWzhuHkmW5RummxJBVbYLkGkaiTOWGxml7SXt0iWa03bzxFIx7wOj3g/ILRd0RcJKBeSQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
-        "@babel/helper-create-class-features-plugin": "^7.22.5",
+        "@babel/helper-create-class-features-plugin": "^7.22.11",
         "@babel/helper-plugin-utils": "^7.22.5",
         "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
       },
@@ -1692,9 +1692,9 @@
       "dev": true
     },
     "node_modules/@babel/runtime": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.10.tgz",
-      "integrity": "sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==",
+      "version": "7.22.11",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.11.tgz",
+      "integrity": "sha512-ee7jVNlWN09+KftVOu9n7S8gQzD/Z6hN/I8VBRXW4P1+Xe7kJGXMwu8vds4aGIMHZnNbdpSWCfZZtinytpcAvA==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -1716,9 +1716,9 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.10.tgz",
-      "integrity": "sha512-Q/urqV4pRByiNNpb/f5OSv28ZlGJiFiiTh+GAHktbIrkPhPbl90+uW6SmpoLyZqutrg9AEaEf3Q/ZBRHBXgxig==",
+      "version": "7.22.11",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.11.tgz",
+      "integrity": "sha512-mzAenteTfomcB7mfPtyi+4oe5BZ6MXxWcn4CX+h4IRJ+OOGXBrWU6jDQavkQI9Vuc5P+donFabBfFCcmWka9lQ==",
       "dependencies": {
         "@babel/code-frame": "^7.22.10",
         "@babel/generator": "^7.22.10",
@@ -1726,8 +1726,8 @@
         "@babel/helper-function-name": "^7.22.5",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.22.10",
-        "@babel/types": "^7.22.10",
+        "@babel/parser": "^7.22.11",
+        "@babel/types": "^7.22.11",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -1736,9 +1736,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.10.tgz",
-      "integrity": "sha512-obaoigiLrlDZ7TUQln/8m4mSqIW2QFeOrCQc9r+xsaHGNoplVNYlRVpsfE8Vj35GEm2ZH4ZhrNYogs/3fj85kg==",
+      "version": "7.22.11",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.11.tgz",
+      "integrity": "sha512-siazHiGuZRz9aB9NpHy9GOs9xiQPKnMzgdr493iI1M67vRXpnEq8ZOOKzezC5q7zwuQ6sDhdSp4SD9ixKSqKZg==",
       "dependencies": {
         "@babel/helper-string-parser": "^7.22.5",
         "@babel/helper-validator-identifier": "^7.22.5",
@@ -1776,9 +1776,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.2.tgz",
-      "integrity": "sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.0.tgz",
+      "integrity": "sha512-JylOEEzDiOryeUnFbQz+oViCXS0KsvR1mvHkoMiu5+UiBvy+RYX7tzlIIIEstF/gVa2tj9AQXk3dgnxv6KxhFg==",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -2007,9 +2007,9 @@
       "integrity": "sha512-0fpHpdiCfdpifsHGeAKNhaTm2l1Lljjf5iSzowYgppLaTEw3Rgm+Bo3+6euatRI6sWK0xLHLpZU0hSCUc2yvJg=="
     },
     "node_modules/@natlibfi/marc-record": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-7.3.0.tgz",
-      "integrity": "sha512-91pHy5t0s5DFfk3SPSdTgm6edYzUpWAYkCdlrTORgzoXiPp9ddjZe7h0tAc372PwKz54pOyG/atILcFAsm9hag==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-7.3.1.tgz",
+      "integrity": "sha512-pN/7sHX+VeLhZNpEwp+RQAA4s2wcvab7axdmMpD81yVMBmLvruVMAiMyBXHAq4O39fTs5s/3o8FTme0dpctGzQ==",
       "dependencies": {
         "debug": "^4.3.4",
         "jsonschema": "^1.4.1"
@@ -2624,9 +2624,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001522",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001522.tgz",
-      "integrity": "sha512-TKiyTVZxJGhsTszLuzb+6vUZSjVOAhClszBr2Ta2k9IwtNBT/4dzmL6aywt0HCgEZlmwJzXJd8yNiob6HgwTRg==",
+      "version": "1.0.30001523",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001523.tgz",
+      "integrity": "sha512-I5q5cisATTPZ1mc588Z//pj/Ox80ERYDfR71YnvY7raS/NOk8xXlZcB0sF7JdqaV//kOaa6aus7lRfpdnt1eBA==",
       "funding": [
         {
           "type": "opencollective",
@@ -2643,9 +2643,9 @@
       ]
     },
     "node_modules/chai": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
-      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.8.tgz",
+      "integrity": "sha512-vX4YvVVtxlfSZ2VecZgFUTU5qPCYsobVI2O9FmwEXBhDigYGQA6jRXCycIs1yJnnWbZ6/+a2zNIF5DfVCcJBFQ==",
       "dev": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
@@ -2968,9 +2968,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.496",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.496.tgz",
-      "integrity": "sha512-qeXC3Zbykq44RCrBa4kr8v/dWzYJA8rAwpyh9Qd+NKWoJfjG5vvJqy9XOJ9H4P/lqulZBCgUWAYi+FeK5AuJ8g=="
+      "version": "1.4.502",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.502.tgz",
+      "integrity": "sha512-xqeGw3Gr6o3uyHy/yKjdnDQHY2RQvXcGC2cfHjccK1IGkH6cX1WQBN8EeC/YpwPhGkBaikDTecJ8+ssxSVRQlw=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -3705,9 +3705,9 @@
       "dev": true
     },
     "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
@@ -4846,9 +4846,9 @@
       "dev": true
     },
     "node_modules/node-fetch": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.13.tgz",
-      "integrity": "sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -5936,9 +5936,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "peer": true,
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,24 @@
 {
   "name": "@natlibfi/marc-record-validators-melinda",
-  "version": "10.12.0-alpha.3",
+  "version": "10.13.0-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@natlibfi/marc-record-validators-melinda",
-      "version": "10.12.0-alpha.3",
+      "version": "10.13.0-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@babel/register": "^7.22.5",
         "@natlibfi/issn-verify": "^1.0.3",
-        "@natlibfi/marc-record": "^7.3.0",
+        "@natlibfi/marc-record": "^7.3.1",
         "@natlibfi/marc-record-validate": "^8.0.1",
         "cld3-asm": "^3.1.1",
         "clone": "^2.1.2",
         "debug": "^4.3.4",
         "isbn3": "^1.1.40",
         "langs": "^2.0.0",
-        "node-fetch": "^2.6.12",
+        "node-fetch": "^2.7.0",
         "xml2js": ">=0.6.2 <1.0.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "git@github.com:natlibfi/marc-record-validators-melinda.git"
   },
   "license": "MIT",
-  "version": "10.12.0-alpha.3",
+  "version": "10.13.0-alpha.1",
   "main": "./dist/index.js",
   "publishConfig": {
     "access": "public"
@@ -37,13 +37,13 @@
   "dependencies": {
     "@babel/register": "^7.22.5",
     "@natlibfi/issn-verify": "^1.0.3",
-    "@natlibfi/marc-record": "^7.3.0",
+    "@natlibfi/marc-record": "^7.3.1",
     "@natlibfi/marc-record-validate": "^8.0.1",
     "cld3-asm": "^3.1.1",
     "debug": "^4.3.4",
     "isbn3": "^1.1.40",
     "langs": "^2.0.0",
-    "node-fetch": "^2.6.12",
+    "node-fetch": "^2.7.0",
     "xml2js": ">=0.6.2 <1.0.0",
     "clone": "^2.1.2"
   },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "git@github.com:natlibfi/marc-record-validators-melinda.git"
   },
   "license": "MIT",
-  "version": "10.11.1",
+  "version": "10.12.0-alpha.3",
   "main": "./dist/index.js",
   "publishConfig": {
     "access": "public"

--- a/src/normalizeFieldForComparison.js
+++ b/src/normalizeFieldForComparison.js
@@ -1,0 +1,312 @@
+/*
+  Note that this file contains very powerful normalizations and spells that are:
+  - meant for comparing similarity/mergability of two fields (clone, normalize, compare),
+  - and NOT for modifying the actual data!
+*/
+import clone from 'clone';
+import {fieldStripPunctuation} from './punctuation2';
+import {fieldToString, isControlSubfieldCode} from './utils.js';
+
+import {fieldNormalizeControlNumbers/*, normalizeControlSubfieldValue*/} from './normalize-identifiers';
+import createDebugLogger from 'debug';
+import {normalizePartData, subfieldContainsPartData} from './normalizeSubfieldValueForComparison';
+
+const debug = createDebugLogger('@natlibfi/melinda-marc-record-merge-reducers:normalize');
+//const debugData = debug.extend('data');
+const debugDev = debug.extend('dev');
+
+function debugFieldComparison(oldField, newField) { // NB: Debug-only function!
+  /*
+  // We may drop certain subfields:
+  if (oldField.subfields.length === newField.subfields.length) { // eslint-disable-line functional/no-conditional-statements
+    oldField.subfields.forEach((subfield, index) => {
+      const newValue = newField.subfields[index].value;
+      if (subfield.value !== newValue) { // eslint-disable-line functional/no-conditional-statements
+        nvdebug(`NORMALIZE SUBFIELD: '${subfield.value}' => '${newValue}'`, debugDev);
+      }
+    });
+  }
+  */
+  const oldString = fieldToString(oldField);
+  const newString = fieldToString(newField);
+  if (oldString === newString) {
+    return;
+  }
+  //nvdebug(`NORMALIZE FIELD:\n '${fieldToString(oldField)}' =>\n '${fieldToString(newField)}'`, debugDev);
+}
+
+function containsHumanName(tag = '???', subfieldCode = undefined) {
+  // NB! This set is for bibs! Auth has 400... What else...
+  if (['100', '600', '700', '800'].includes(tag)) {
+    if (subfieldCode === undefined || subfieldCode === 'a') {
+      return true;
+    }
+  }
+  // Others?
+  return false;
+}
+
+function containsCorporateName(tag = '???', subfieldCode = undefined) {
+  // NB! This set is for bibs! Auth has 400... What else...
+  if (['110', '610', '710', '810'].includes(tag)) {
+    if (subfieldCode === undefined || subfieldCode === 'a') {
+      return true;
+    }
+  }
+  // Others?
+  return false;
+}
+
+function skipAllSubfieldNormalizations(value, subfieldCode, tag) {
+
+
+  if (subfieldCode === 'g' && value === 'ENNAKKOTIETO.') {
+    return true;
+  }
+
+
+  if (tag === '035' && ['a', 'z'].includes(subfieldCode)) { // A
+    return true;
+  }
+
+  if (isControlSubfieldCode(subfieldCode)) {
+    return true;
+  }
+  return false;
+}
+
+function skipSubfieldLowercase(value, subfieldCode, tag) {
+  // These may contain Roman Numerals...
+  if (subfieldContainsPartData(tag, subfieldCode)) {
+    return true;
+  }
+
+  return skipAllSubfieldNormalizations(value, subfieldCode, tag);
+}
+
+function skipAllFieldNormalizations(tag) {
+  if (['LOW', 'SID'].includes(tag)) {
+    return true;
+  }
+  return false;
+}
+
+
+function subfieldValueLowercase(value, subfieldCode, tag) {
+  if (skipSubfieldLowercase(value, subfieldCode, tag)) {
+    return value;
+  }
+
+  //return value.toLowerCase();
+  const newValue = value.toLowerCase();
+  if (newValue !== value) {
+    //nvdebug(`SVL ${tag} $${subfieldCode} '${value}' =>`, debugDev);
+    //nvdebug(`SVL ${tag} $${subfieldCode} '${newValue}'`, debugDev);
+    return newValue;
+  }
+  return value;
+}
+
+function subfieldLowercase(sf, tag) {
+  sf.value = subfieldValueLowercase(sf.value, sf.code, tag); // eslint-disable-line functional/immutable-data
+}
+
+function fieldLowercase(field) {
+  if (skipFieldLowercase(field)) {
+    return;
+  }
+
+  field.subfields.forEach(sf => subfieldLowercase(sf, field.tag));
+
+  function skipFieldLowercase(field) {
+    if (skipAllFieldNormalizations(field.tag)) {
+      return true;
+    }
+    // Skip non-interesting fields
+    if (!containsHumanName(field.tag) && !containsCorporateName(field.tag) && !['240', '245', '630'].includes(field.tag)) {
+      return true;
+    }
+
+    return false;
+  }
+}
+
+
+function hack490SubfieldA(field) {
+  if (field.tag !== '490') {
+    return;
+  }
+  field.subfields.forEach(sf => removeSarja(sf));
+
+  // NB! This won't work, if the punctuation has not been stripped beforehand!
+  function removeSarja(subfield) {
+    if (subfield.code !== 'a') {
+      return;
+    }
+    const tmp = subfield.value.replace(/ ?-(?:[a-z]|ä|ö)*sarja$/u, '');
+    if (tmp.length > 0) {
+      subfield.value = tmp; // eslint-disable-line functional/immutable-data
+      return;
+    }
+  }
+}
+
+export function tagAndSubfieldCodeReferToIsbn(tag, subfieldCode) {
+  // NB! We don't do this to 020$z!
+  if (subfieldCode === 'z' && ['765', '767', '770', '772', '773', '774', '776', '777', '780', '785', '786', '787'].includes(tag)) {
+    return true;
+  }
+  if (tag === '020' && subfieldCode === 'a') {
+    return true;
+  }
+  return false;
+}
+
+function looksLikeIsbn(value) {
+  // Does not check validity!
+  if (value.match(/^(?:[0-9]-?){9}(?:[0-9]-?[0-9]-?[0-9]-?)?[0-9Xx]$/u)) {
+    return true;
+  }
+  return false;
+}
+
+function normalizeISBN(field) {
+  if (!field.subfields) {
+    return;
+  }
+
+  //nvdebug(`ISBN-field? ${fieldToString(field)}`);
+  const relevantSubfields = field.subfields.filter(sf => tagAndSubfieldCodeReferToIsbn(field.tag, sf.code) && looksLikeIsbn(sf.value));
+  relevantSubfields.forEach(sf => normalizeIsbnSubfield(sf));
+
+  function normalizeIsbnSubfield(sf) {
+    //nvdebug(` ISBN-subfield? ${subfieldToString(sf)}`);
+    sf.value = sf.value.replace(/-/ug, ''); // eslint-disable-line functional/immutable-data
+    sf.value = sf.value.replace(/x/u, 'X'); // eslint-disable-line functional/immutable-data
+  }
+
+}
+
+function fieldSpecificHacks(field) {
+  normalizeISBN(field); // 020$a, not $z!
+  hack490SubfieldA(field);
+}
+
+export function fieldTrimSubfieldValues(field) {
+  field.subfields?.forEach((sf) => {
+    sf.value = sf.value.replace(/^[ \t\n]+/u, ''); // eslint-disable-line functional/immutable-data
+    sf.value = sf.value.replace(/[ \t\n]+$/u, ''); // eslint-disable-line functional/immutable-data
+    sf.value = sf.value.replace(/[ \t\n]+/gu, ' '); // eslint-disable-line functional/immutable-data
+  });
+}
+
+function fieldRemoveDecomposedDiacritics(field) {
+  // Raison d'être/motivation: "Sirén" and diacriticless "Siren" might refer to a same surname, so this normalization
+  // allows us to compare authors and avoid duplicate fields.
+  field.subfields.forEach((sf) => {
+    sf.value = removeDecomposedDiacritics(sf.value); // eslint-disable-line functional/immutable-data
+  });
+}
+
+function removeDecomposedDiacritics(value = '') {
+  // NB #1: Does nothing to precomposed letters. Do String.normalize('NFD') first, if you want to handle them.
+  // NB #2: Finnish letters 'å', 'ä', 'ö', 'Å', Ä', and 'Ö' should be handled (=precomposed) before calling this. (= keep them as is)
+  // NB #3: Calling our very own fixComposition() before this function handles both #1 and #2.
+  return String(value).replace(/\p{Diacritic}/gu, '');
+}
+
+function normalizeSubfieldValue(value, subfieldCode, tag) {
+  // NB! For comparison of values only
+  /* eslint-disable */
+  value = subfieldValueLowercase(value, subfieldCode, tag);
+
+  // Normalize: s. = sivut = pp.
+  value = normalizePartData(value, subfieldCode, tag);
+  value = value.replace(/^\[([^[\]]+)\]/gu, '$1'); // eslint-disable-line functional/immutable-data, prefer-named-capture-group
+
+  if (['130', '730'].includes(tag) && subfieldCode === 'a') {
+    value = value.replace(' : ', ', '); // "Halloween ends (elokuva, 2022)" vs "Halloween ends (elokuva : 2023)"
+  }
+  /* eslint-enable */
+
+  // Not going to do these in the foreseeable future, but keeping them here for discussion:
+  // Possible normalizations include but are not limited to:
+  // ø => ö? Might be language dependent: 041 $a fin => ö, 041 $a eng => o?
+  // Ø => Ö?
+  // ß => ss
+  // þ => th (NB! Both upper and lower case)
+  // ...
+  // Probably nots:
+  // ü => y (probably not, though this correlates with Finnish letter-to-sound rules)
+  // w => v (OK for Finnish sorting in certain cases, but we are not here, are we?)
+  // I guess we should use decomposed values in code here. (Not sure what composition my examples above use.)
+  return value;
+}
+
+export function cloneAndRemovePunctuation(field) {
+  const clonedField = clone(field);
+  if (fieldSkipNormalization(field)) {
+    return clonedField;
+  }
+  fieldStripPunctuation(clonedField);
+  fieldTrimSubfieldValues(clonedField);
+  debugDev('PUNC');
+  debugFieldComparison(field, clonedField);
+
+  return clonedField;
+}
+
+function removeCharsThatDontCarryMeaning(value, tag, subfieldCode) {
+  if (tag === '080') {
+    return value;
+  }
+  /* eslint-disable */
+  // 3" refers to inches, but as this is for comparison only we don't mind...
+  value = value.replace(/['"]/gu, '');
+  // MRA-273: Handle X00$a name initials.
+  // NB #1: that we remove spaces for comparison (as it simpler), though actually space should be used. Doesn't matter as this is comparison only.
+  // NB #2: we might/should eventually write a validator/fixer that adds those spaces. After that point, this expection should become obsolete.
+  if (subfieldCode === 'a' && ['100', '400', '600', '700', '800'].includes(tag)) { // 400 is used in auth records. It's not a bib field at all.
+    value = value.replace(/([A-Z]|Å|Ä|Ö)\. +/ugi, '$1.');
+  }
+  /* eslint-enable */
+  return value;
+}
+
+function normalizeField(field) {
+  //sf.value = removeDecomposedDiacritics(sf.value); // eslint-disable-line functional/immutable-data
+  fieldStripPunctuation(field);
+  fieldLowercase(field);
+  fieldNormalizeControlNumbers(field); // FIN11 vs FI-MELINDA etc.
+  return field;
+}
+
+export function cloneAndNormalizeFieldForComparison(field) {
+  // NB! This new field is for comparison purposes only.
+  // Some of the normalizations might be considered a bit overkill for other purposes.
+  const clonedField = clone(field);
+  if (fieldSkipNormalization(field)) {
+    return clonedField;
+  }
+  clonedField.subfields.forEach((sf) => { // Do this for all fields or some fields?
+    sf.value = normalizeSubfieldValue(sf.value, sf.code, field.tag); // eslint-disable-line functional/immutable-data
+    sf.value = removeCharsThatDontCarryMeaning(sf.value, field.tag, sf.code);// eslint-disable-line functional/immutable-data
+  });
+
+  normalizeField(clonedField); // eslint-disable-line functional/immutable-data
+  fieldRemoveDecomposedDiacritics(clonedField);
+  fieldSpecificHacks(clonedField);
+  fieldTrimSubfieldValues(clonedField);
+
+
+  debugFieldComparison(field, clonedField); // For debugging purposes only
+
+  return clonedField;
+}
+
+function fieldSkipNormalization(field) {
+  if (!field.subfields || ['018', '066', '080', '083'].includes(field.tag)) {
+    return true;
+  }
+  return false;
+}

--- a/src/normalizeSubfieldValueForComparison.js
+++ b/src/normalizeSubfieldValueForComparison.js
@@ -1,0 +1,96 @@
+import {nvdebug} from './utils';
+import createDebugLogger from 'debug';
+
+// Normalizes at least 490$v and 773$g which contain information such as "Raita 5" vs "5", and "Osa 3" vs "Osa III".
+
+const debug = createDebugLogger('@natlibfi/melinda-marc-record-merge-reducers:normalizePart');
+//const debugData = debug.extend('data');
+const debugDev = debug.extend('dev');
+
+export function subfieldContainsPartData(tag, subfieldCode) {
+  if (subfieldCode === 'v' && ['490', '800', '810', '811', '830'].includes(tag)) {
+    return true;
+  }
+  if (tag === '773' && subfieldCode === 'g') {
+    return true;
+  }
+  return false;
+}
+
+function splitPartData(originalValue) {
+  const value = originalValue.replace(/^\[([0-9]+)\][-.,:; ]*$/ui, '$1'); // eslint-disable-line prefer-named-capture-group
+  const splitPoint = value.lastIndexOf(' ');
+  if (splitPoint === -1) {
+    return [undefined, value];
+  }
+  const lhs = value.substr(0, splitPoint);
+  const rhs = value.substr(splitPoint + 1);
+  return [lhs, rhs];
+}
+
+function normalizePartType(originalValue) {
+  if (originalValue === undefined) {
+    return undefined;
+  }
+  const value = originalValue.toLowerCase();
+  // Return Finnish singular nominative. Best-ish for debug purposes...
+  if (['osa', 'part', 'teil'].includes(value)) {
+    return 'osa';
+  }
+  if (['p.', 'page', 'pages', 'pp.', 's.', 'sidor', 'sivu', 'sivut'].includes(value)) {
+    return 'sivu';
+  }
+  return value;
+}
+
+const romanNumbers = {'I': '1', 'II': '2', 'III': '3', 'IV': '4', 'V': '5', 'VI': '6', 'X': '10'};
+
+function normalizePartNumber(value) {
+  // Should we handle all Roman numbers or some range of them?
+  // There's probably a library for our purposes..
+  if (value in romanNumbers) {
+    const arabicValue = romanNumbers[value];
+    nvdebug(` MAP ${value} to ${arabicValue}`, debugDev);
+    return arabicValue;
+  }
+  return value.toLowerCase();
+}
+
+function splitAndNormalizePartData(value) {
+  // This is just a stub. Does not handle eg. "Levy 2, raita 15"
+  const [lhs, rhs] = splitPartData(value);
+  nvdebug(`  LHS: '${lhs}'`, debugDev);
+  nvdebug(`  RHS: '${rhs}'`, debugDev);
+  const partType = normalizePartType(lhs);
+  const partNumber = normalizePartNumber(rhs);
+  return [partType, partNumber];
+}
+
+export function partsAgree(value1, value2, tag, subfieldCode) {
+  if (!subfieldContainsPartData(tag, subfieldCode)) {
+    return false;
+  }
+  const [partType1, partNumber1] = splitAndNormalizePartData(value1);
+  const [partType2, partNumber2] = splitAndNormalizePartData(value2);
+  if (partNumber1 !== partNumber2) {
+    return false;
+  }
+  if (partType1 === undefined || partType2 === undefined || partType1 === partType2) {
+    return true;
+  }
+
+  return false;
+}
+
+export function normalizePartData(value, subfieldCode, tag) {
+  // This is for normalizing values for equality comparison only!
+  if (!subfieldContainsPartData(tag, subfieldCode)) {
+    return value;
+  }
+
+  const [partType, partNumber] = splitAndNormalizePartData(value);
+  if (partType === undefined) {
+    return partNumber;
+  }
+  return `${partType} ${partNumber}`;
+}

--- a/src/prepublicationUtils.js
+++ b/src/prepublicationUtils.js
@@ -1,0 +1,263 @@
+import {fieldHasSubfield, nvdebug, nvdebugFieldArray} from './utils';
+import createDebugLogger from 'debug';
+
+const debug = createDebugLogger('@natlibfi/marc-record-validators-melinda:prepublicationUtils');
+//const debugData = debug.extend('data');
+const debugDev = debug.extend('dev');
+
+const KONEELLISESTI_TUOTETTU_TIETUE = 1; // Best
+const TARKISTETTU_ENNAKKOTIETO = 2;
+const ENNAKKOTIETO = 3;
+//const EI_TASOA = 4;
+
+const encodingLevelPreferenceArray = [' ', '1', '3', '4', '5', '2', '7', 'u', 'z', '8']; // MET-145
+const prepublicationLevelIndex = encodingLevelPreferenceArray.indexOf('8');
+
+export function prepublicationLevelIsKoneellisestiTuotettuTietueOrTarkistettuEnnakkotieto(prepublicationLevel) {
+  return prepublicationLevel === KONEELLISESTI_TUOTETTU_TIETUE || prepublicationLevel === TARKISTETTU_ENNAKKOTIETO;
+}
+
+
+export function encodingLevelIsBetterThanPrepublication(encodingLevel) {
+  const index = encodingLevelPreferenceArray.indexOf(encodingLevel);
+  return index > -1 && index < prepublicationLevelIndex;
+}
+
+
+function containsSubstringInSubfieldA(field, substring) {
+  return field.subfields.some(sf => sf.code === 'a' && sf.value.includes(substring));
+}
+
+
+// These three functions below all refer to field 500:
+export function fieldRefersToKoneellisestiTuotettuTietue(field) {
+  return containsSubstringInSubfieldA(field, 'Koneellisesti tuotettu tietue');
+}
+
+
+export function fieldRefersToTarkistettuEnnakkotieto(field) {
+  return containsSubstringInSubfieldA(field, 'TARKISTETTU ENNAKKOTIETO');
+}
+
+
+export function fieldRefersToEnnakkotieto(field) {
+  // NB! This matches also 'TARKISTETTU ENNAKKOTIETO' case!
+  return containsSubstringInSubfieldA(field, 'ENNAKKOTIETO');
+}
+
+
+export function firstFieldHasBetterPrepubEncodingLevel(field1, field2) {
+  if (fieldRefersToKoneellisestiTuotettuTietue(field2)) {
+    return false;
+  }
+  if (fieldRefersToKoneellisestiTuotettuTietue(field1)) {
+    return true;
+  }
+  if (fieldRefersToTarkistettuEnnakkotieto(field2)) {
+    return false;
+  }
+  if (fieldRefersToTarkistettuEnnakkotieto(field1)) {
+    return true;
+  }
+  if (fieldRefersToEnnakkotieto(field2)) {
+    return false;
+  }
+  if (fieldRefersToEnnakkotieto(field1)) {
+    return true;
+  }
+  return false;
+}
+
+/*
+export function firstFieldHasEqualOrBetterPrepubEncodingLevel(field1, field2) {
+  // Could be optimized...
+  if (fieldRefersToKoneellisestiTuotettuTietue(field1)) {
+    return true;
+  }
+  if (fieldRefersToKoneellisestiTuotettuTietue(field2)) {
+    return false;
+  }
+  if (fieldRefersToTarkistettuEnnakkotieto(field1)) {
+    return true;
+  }
+  if (fieldRefersToTarkistettuEnnakkotieto(field2)) {
+    return false;
+  }
+  if (fieldRefersToEnnakkotieto(field1)) {
+    return true;
+  }
+  return !fieldRefersToEnnakkotieto(field2);
+}
+*/
+
+/*
+function hasEnnakkotietoSubfield(field) {
+  return field.subfields.some(sf => ['g', '9'].includes(sf.code) && sf.value.includes('ENNAKKOTIETO'));
+}
+*/
+
+/*
+export function isPrepublicationField6XX(field) {
+  if (!field.tag.match(/^6(?:[0-4][0-9]|5[0-5])$/u)) { // Not within 600 ... 655 range
+    return false;
+  }
+  return field.subfields.some(sf => hasEnnakkotietoSubfield(sf));
+}
+*/
+
+
+export function getRelevant5XXFields(record, f500 = false, f594 = false) {
+  const cands = actualGetFields();
+  //nvdebugFieldArray(cands, 'gR5XXa: ', debugDev);
+  const filtered = cands.filter(field => hasRelevantPrepubData(field));
+  //nvdebugFieldArray(filtered, 'gR5XXb: ', debugDev);
+  return filtered;
+
+  //return actualGetFields().filter(field => hasRelevantPrepubData(field));
+
+  function hasRelevantPrepubData(field) {
+    // Check prepub ($a):
+    if (!fieldRefersToKoneellisestiTuotettuTietue(field) && !fieldRefersToEnnakkotieto(field)) {
+      return false;
+    }
+    // Check relevance (594$5):
+    if (field.tag === '500') {
+      return field.subfields.every(sf => sf.code !== '5'); //true;
+    }
+    return field.subfields.some(sf => sf.code === '5' && ['FENNI', 'FIKKA', 'VIOLA'].includes(sf.value));
+  }
+
+  function actualGetFields() {
+    if (f500 && f594) {
+      return record.get(/^(?:500|594)$/u);
+    }
+    if (f500) {
+      return record.get(/^500$/u);
+    }
+    if (f594) {
+      return record.get(/^594$/u);
+    }
+    return [];
+  }
+
+}
+
+
+// Very similar to getPrepublicationLevel() in melinda-record-match-validator's getPrepublicationLevel()...
+// We should use that and not have a copy here...
+export function getPrepublicationLevel(record, f500 = false, f594 = false) {
+  // Smaller return value is better
+  const fields = getRelevant5XXFields(record, f500, f594);
+
+  if (!fields) {
+    return null;
+  }
+  if (fields.some(f => fieldRefersToKoneellisestiTuotettuTietue(f))) {
+    return KONEELLISESTI_TUOTETTU_TIETUE;
+  }
+
+  if (fields.some(f => fieldRefersToTarkistettuEnnakkotieto(f))) {
+    return TARKISTETTU_ENNAKKOTIETO;
+  }
+
+  if (fields.some(f => fieldRefersToEnnakkotieto(f))) {
+    return ENNAKKOTIETO;
+  }
+
+  return null;
+}
+
+
+export function baseHasEqualOrHigherEncodingLevel(baseEncodingLevel, sourceEncodingLevel) {
+  const baseIndex = encodingLevelPreferenceArray.indexOf(baseEncodingLevel);
+  const sourceIndex = encodingLevelPreferenceArray.indexOf(sourceEncodingLevel);
+
+  if (baseIndex === -1) {
+    // Base wins if both are bad:
+    return sourceIndex === -1;
+  }
+  return baseIndex <= sourceIndex;
+}
+
+
+function hasFikkaLOW(record) {
+  return record.fields.some(field => field.tag === 'LOW' && fieldHasSubfield(field, 'a', 'FIKKA'));
+}
+
+
+function hasNatLibFi042(record) {
+  return record.fields.some(field => field.tag === '042' && (fieldHasSubfield(field, 'a', 'finb') || fieldHasSubfield(field, 'a', 'finbd')));
+}
+
+
+export function isFikkaRecord(record) {
+  // NB! Does not include Humaniora. Pienpainatteet (not that they'd have duplicates)?
+  return hasFikkaLOW(record) && hasNatLibFi042(record);
+}
+
+
+export function getEncodingLevel(record) {
+  return record.leader.substring(17, 18);
+}
+
+
+export function deleteAllPrepublicationNotesFromField500InNonPubRecord(record) {
+  const encodingLevel = getEncodingLevel(record);
+  // Skip prepublication (or theoretically even worse) records:
+  if (!encodingLevelIsBetterThanPrepublication(encodingLevel)) {
+  //if (['2', '8'].includes(encodingLevel)) { // MET-306: added '2' here
+    return;
+  }
+
+  // MET-306: keep "koneellisesti tuotettu tietue" if encodng level is '2':
+  const f500 = getRelevant5XXFields(record, true, false).filter(field => encodingLevel === '2' ? !fieldRefersToKoneellisestiTuotettuTietue(field) : true);
+  if (f500.length === 0) {
+    return;
+  }
+
+
+  nvdebug(`Delete all ${f500.length} instance(s) of field 500`, debugDev);
+  f500.forEach(field => record.removeField(field));
+}
+
+
+export function removeWorsePrepubField500s(record) {
+  // Remove lower-level entries:
+  const fields = getRelevant5XXFields(record, true, false); // 500=false, 594=true
+  nvdebugFieldArray(fields, '  Candidates for non-best 500 b4 filtering: ', debugDev);
+  const nonBest = fields.filter(field => fields.some(field2 => firstFieldHasBetterPrepubEncodingLevel(field2, field)));
+  nvdebugFieldArray(nonBest, '  Remove non-best 500: ', debugDev);
+  nonBest.forEach(field => record.removeField(field));
+}
+
+
+export function removeWorsePrepubField594s(record) {
+  // Remove lower-level entries:
+  const fields594 = getRelevant5XXFields(record, false, true); // 500=false, 594=true
+  nvdebugFieldArray(fields594, '  Candidates for non-best 594 b4 filtering: ', debugDev);
+  const nonBest = fields594.filter(field => fields594.some(field2 => firstFieldHasBetterPrepubEncodingLevel(field2, field)));
+  nvdebugFieldArray(nonBest, '  Remove non-best 594: ', debugDev);
+  nonBest.forEach(field => record.removeField(field));
+}
+
+
+export function isEnnakkotietoSubfield(subfield) {
+  if (subfield.code !== '9' && subfield.code !== 'g') {
+    return false;
+  }
+  // Length <= 13 allows punctuation, but does not require it:
+  if (subfield.value.substr(0, 12) === 'ENNAKKOTIETO' && subfield.value.length <= 13) {
+    return true;
+  }
+  return false;
+}
+
+export function isEnnakkotietoField(field) {
+  return field.subfields.some(sf => isEnnakkotietoSubfield(sf));
+}
+
+export function isKingOfTheHill(field, opposingFields) {
+  // Field is no better than at least one of the opposing fields
+  return opposingFields.every(opposingField => firstFieldHasBetterPrepubEncodingLevel(field, opposingField));
+}
+

--- a/src/punctuation2.js
+++ b/src/punctuation2.js
@@ -308,7 +308,7 @@ const addPairedPunctuationRules = {
   '800': addX00,
   '810': addX10,
   '830': addSeriesTitle,
-  '946': add246
+  '946': [{'code': 'i', 'followedBy': 'a', 'add': ':', 'context': defaultNeedsPuncAfter}]
 };
 
 

--- a/src/punctuation2.js
+++ b/src/punctuation2.js
@@ -137,6 +137,16 @@ const remove490And830Whatever = [{'code': 'axyzv', 'followedBy': 'axyzv', 'remov
 
 const linkingEntryWhatever = [{'code': 'abdghiklmnopqrstuwxyz', 'followedBy': 'abdghiklmnopqrstuwxyz', 'remove': /\. -$/u}];
 
+
+// '!' means negation, thus '!b' means any other subfield but 'b'.
+// 'followedBy': '#' means that current subfield is the last subfield.
+// NB! Note that control subfields are ignored in punctuation rules.
+// NB #2! Control field ignorance causes issues with field 257: https://wiki.helsinki.fi/display/rdasovellusohje/Loppupisteohje
+//        Might need to work on that at some point. NOT a top priority though.
+// NB #3! Final punctuation creation is/should be handled by endind-punctuation.js validator!
+
+const crappy246 = [{'code': 'abfghinp', 'followedBy': '#', 'remove': /\.$/u, 'context': dotIsProbablyPunc}];
+
 const cleanCrappyPunctuationRules = {
   '100': removeX00Whatever,
   '110': removeX10Whatever,
@@ -144,6 +154,7 @@ const cleanCrappyPunctuationRules = {
     {'code': 'ab', 'followedBy': '!c', 'remove': / \/$/u},
     {'code': 'abc', 'followedBy': '#', 'remove': /\.$/u, 'context': dotIsProbablyPunc}
   ],
+  '246': crappy246,
   '300': [
     {'code': 'a', 'followedBy': '!b', 'remove': / *:$/u},
     {'code': 'a', 'followedBy': 'b', 'remove': /:$/u, 'context': /[^ ]:$/u},
@@ -163,8 +174,8 @@ const cleanCrappyPunctuationRules = {
   '776': linkingEntryWhatever,
   '800': removeX00Whatever,
   '810': removeX10Whatever,
-  '830': remove490And830Whatever
-
+  '830': remove490And830Whatever,
+  '946': crappy246
 };
 
 const cleanLegalX00Comma = {'code': 'abcde', 'followedBy': 'cdegj', 'context': /.,$/u, 'remove': /,$/u};
@@ -187,6 +198,17 @@ const cleanLegalSeriesTitle = [ // 490 and 830
   {'code': 'axyz', 'followedBy': 'v', 'remove': / *;$/u}
 ];
 
+const clean24X = [
+  {'name': 'I:A', 'code': 'i', 'followedBy': 'a', 'remove': / *:$/u},
+  {'name': 'A:B', 'code': 'a', 'followedBy': 'b', 'remove': / [:;=]$/u},
+  {'name': 'AB:K', 'code': 'ab', 'followedBy': 'k', 'remove': / :$/u},
+  {'name': 'ABK:F', 'code': 'abk', 'followedBy': 'f', 'remove': /,$/u},
+  {'name': 'ABFNP:C', 'code': 'abfnp', 'followedBy': 'c', 'remove': / \/$/u},
+  {'name': 'ABN:N', 'code': 'abn', 'followedBy': 'n', 'remove': /\.$/u},
+  {'name': 'ABNP:#', 'code': 'abnp', 'followedBy': '#', 'remove': /\.$/u},
+  {'name': 'N:P', 'code': 'n', 'followedBy': 'p', 'remove': /,$/u}
+];
+
 const cleanValidPunctuationRules = {
   '100': legalX00punc,
   '110': legalX10punc,
@@ -196,16 +218,8 @@ const cleanValidPunctuationRules = {
   '710': legalX10punc,
   '800': legalX00punc,
   '810': legalX10punc,
-  '245': [
-    {'name': 'A:B', 'code': 'a', 'followedBy': 'b', 'remove': / [:;=]$/u},
-    {'name': 'AB:K', 'code': 'ab', 'followedBy': 'k', 'remove': / :$/u},
-    {'name': 'ABK:F', 'code': 'abk', 'followedBy': 'f', 'remove': /,$/u},
-    {'name': 'ABFNP:C', 'code': 'abfnp', 'followedBy': 'c', 'remove': / \/$/u},
-    {'name': 'ABN:N', 'code': 'abn', 'followedBy': 'n', 'remove': /\.$/u},
-    {'name': 'ABNP:#', 'code': 'abnp', 'followedBy': '#', 'remove': /\.$/u},
-    {'name': 'N:P', 'code': 'n', 'followedBy': 'p', 'remove': /,$/u}
-
-  ],
+  '245': clean24X,
+  '246': clean24X,
   '260': [
     {'code': 'a', 'followedBy': 'b', 'remove': / :$/u},
     {'code': 'b', 'followedBy': 'c', 'remove': /,$/u},
@@ -229,13 +243,30 @@ const cleanValidPunctuationRules = {
   '534': [{'code': 'p', 'followedBy': 'c', 'remove': /:$/u}],
   // Experimental, MET366-ish (end punc in internationally valid, but we don't use it here in Finland):
   '648': [{'code': 'a', 'content': /^[0-9]+\.$/u, 'ind2': ['4'], 'remove': /\.$/u}],
-  '830': cleanLegalSeriesTitle
+  '830': cleanLegalSeriesTitle,
+  '946': clean24X
 
 };
 
 // addColonToRelationshipInformation only applies to 700/710 but as others don't have $i, it's fine
 const addX00 = [addX00aComma, addX00aComma2, addX00aDot, addLanguageComma, addSemicolonBeforeVolumeDesignation, addColonToRelationshipInformation];
 const addX10 = [addX10bDot, addX10eComma, addX10Dot, addLanguageComma, addSemicolonBeforeVolumeDesignation, addColonToRelationshipInformation];
+
+const add245 = [
+  // Blah! Also "$a = $b" and "$a ; $b" can be valid... But ' :' is better than nothing, I guess...
+  {'code': 'a', 'followedBy': 'b', 'add': ' :', 'context': defaultNeedsPuncAfter},
+  {'code': 'abk', 'followedBy': 'f', 'add': ',', 'context': defaultNeedsPuncAfter},
+  {'code': 'abfnp', 'followedBy': 'c', 'add': ' /', 'context': defaultNeedsPuncAfter},
+  {'code': 'abc', 'followedBy': '#', 'add': '.', 'context': defaultNeedsPuncAfter} // Stepping on punctuation/ toes
+];
+
+const add246 = [
+  {'code': 'i', 'followedBy': 'a', 'add': ':', 'context': defaultNeedsPuncAfter},
+  {'code': 'a', 'followedBy': 'b', 'add': ' :', 'context': defaultNeedsPuncAfter},
+  {'code': 'abk', 'followedBy': 'f', 'add': ',', 'context': defaultNeedsPuncAfter},
+  {'code': 'abfnp', 'followedBy': 'c', 'add': ' /', 'context': defaultNeedsPuncAfter}
+];
+
 
 const addSeriesTitle = [ // 490 and 830
   {'code': 'a', 'followedBy': 'a', 'add': ' =', 'context': defaultNeedsPuncAfter2},
@@ -246,13 +277,8 @@ const addSeriesTitle = [ // 490 and 830
 const addPairedPunctuationRules = {
   '100': addX00,
   '110': addX10,
-  '245': [
-    // Blah! Also "$a = $b" and "$a ; $b" can be valid... But ' :' is better than nothing, I guess...
-    {'code': 'a', 'followedBy': 'b', 'add': ' :', 'context': defaultNeedsPuncAfter},
-    {'code': 'abk', 'followedBy': 'f', 'add': ',', 'context': defaultNeedsPuncAfter},
-    {'code': 'abfnp', 'followedBy': 'c', 'add': ' /', 'context': defaultNeedsPuncAfter},
-    {'code': 'abc', 'followedBy': '#', 'add': '.', 'context': defaultNeedsPuncAfter} // Stepping on punctuation/ toes
-  ],
+  '245': add245,
+  '246': add246,
   '260': [
     {'code': 'a', 'followedBy': 'b', 'add': ' :', 'context': defaultNeedsPuncAfter2},
     {'code': 'b', 'followedBy': 'c', 'add': ',', 'context': defaultNeedsPuncAfter2},
@@ -281,7 +307,8 @@ const addPairedPunctuationRules = {
   '710': addX10,
   '800': addX00,
   '810': addX10,
-  '830': addSeriesTitle
+  '830': addSeriesTitle,
+  '946': add246
 };
 
 
@@ -408,11 +435,11 @@ function subfieldFixPunctuation(field, subfield1, subfield2) {
 }
 
 function subfieldStripPunctuation(field, subfield1, subfield2) {
-  nvdebug(`FSP1: '${subfield1.value}'`);
+  //nvdebug(`FSP1: '${subfield1.value}'`);
   applyPunctuationRules(field, subfield1, subfield2, cleanValidPunctuationRules, REMOVE);
-  nvdebug(`FSP2: '${subfield1.value}'`);
+  //nvdebug(`FSP2: '${subfield1.value}'`);
   applyPunctuationRules(field, subfield1, subfield2, cleanCrappyPunctuationRules, REMOVE);
-  nvdebug(`FSP3: '${subfield1.value}'`);
+  //nvdebug(`FSP3: '${subfield1.value}'`);
 
 }
 

--- a/src/removeInferiorDataFields.js
+++ b/src/removeInferiorDataFields.js
@@ -3,6 +3,7 @@ import {fieldToChain, sameField} from './removeDuplicateDataFields';
 import {fieldGetOccurrenceNumberPairs, fieldHasValidSubfield6, fieldSevenToOneOccurrenceNumber, fieldsToNormalizedString} from './subfield6Utils';
 import {fieldsToString, fieldToString, nvdebug} from './utils';
 import {fieldHasValidSubfield8} from './subfield8Utils';
+import {encodingLevelIsBetterThanPrepublication, getEncodingLevel} from './prepublicationUtils';
 
 // Relocated from melinda-marc-record-merge-reducers (and renamed)
 
@@ -70,6 +71,14 @@ function deriveInferiorChains(fields, record) {
       deletableStringsObject[tmp] = field;
       //nvdebug(`FFS: ${tmp}`);
     }
+
+    // MRA-433: 490 ind1=1 vs ind1=0: remove latter (luckily no 2nd indicator etc)
+    if (chainAsString.match(/^490 1 .*\t880 1  ‡/) ) {
+      // change ind1s to '0' to get the deletable chain:
+      tmp = chainAsString.replace(/^490 1/u, '490 0').replace(/\t880 1/ug, "\t880 0");
+      deletableStringsObject[tmp] = field;
+    }
+
   }
 
 
@@ -124,7 +133,8 @@ export function removeInferiorChains(record, fix = true) {
     return chain.some(f => f.tag.substring(0, 1) === '1');
   }
 
-  function sevenToOne(field, chain) {
+  function sevenToOne(field, chain) { // Change 7XX field to 1XX field. Also handle the corresponding 880$6 7XX-NN subfields
+    // NB! This function should be called only if the original 1XX gets deleted!
     if (!['700', '710', '711', '730'].includes(field.tag)) {
       return;
     }
@@ -141,26 +151,16 @@ export function removeInferiorChains(record, fix = true) {
       return;
     }
 
-    // Better to keep inferior 1XX (vs better 7XX) than to delete 1XX!
-    if(chain.some(f => f.tag.substring(0, 1) === '1')) {
-      return;
-    }
-
     const chainAsString = fieldsToNormalizedString(chain, 0, true, true);
     if (chainAsString in deletableChainsAsKeys) {
       const triggeringField = deletableChainsAsKeys[chainAsString];
       const triggeringChain = fieldToChain(triggeringField, record);
 
-      // 1XX may be converted to XXX. However, it should not be removed.
-      // Better to keep inferior 1XX (vs better 7XX) than to delete 1XX!
+      // If the inferior (deletable) chain is 1XX-based, convert the triggering better chain from 7XX to 1XX:
       if(chainContains1XX(chain)) {
-        if (chainContains1XX(triggeringChain)) {
-          // This should *never* happen, but keep this as a sanity check
-          return;
-        }
         triggeringChain.forEach(f => sevenToOne(f, triggeringChain));
       }
-      nvdebug(`iRIS6C: ${chainAsString}`);
+      //nvdebug(`iRIS6C: ${chainAsString}`);
       const deletedString = fieldsToString(chain);
       const message = `DEL: '${deletedString}'  REASON: '${fieldsToString(triggeringChain)}'`;
       deletedStringsArray.push(message);
@@ -179,11 +179,14 @@ function deriveIndividualDeletables(record) {
   /* eslint-disable */
   let deletableStringsArray = [];
 
+  const finishedRecord = encodingLevelIsBetterThanPrepublication(getEncodingLevel(record));
+
   record.fields.forEach(field => fieldDeriveIndividualDeletables(field));
 
   function fieldDeriveIndividualDeletables(field) {
     const fieldAsString = fieldToString(field);
 
+    nvdebug(`Derivations for ${fieldAsString}`);
     // Proof-of-concept rule:
     let tmp = fieldAsString;
     if (field.tag.match(/^[1678]00$/u)) {
@@ -192,6 +195,7 @@ function deriveIndividualDeletables(record) {
         deletableStringsArray.push(tmp);
       }
     }
+
     // MET-381: remove occurence number TAG-00, if TAG-NN existists
     if (field.tag === '880') {
       tmp = fieldAsString;
@@ -212,10 +216,30 @@ function deriveIndividualDeletables(record) {
     // Remove keepless versions:
     tmp = fieldAsString;
     while (tmp.match(/ ‡9 [A-Z]+<KEEP>/)) {
-      tmp = tmp.replace(/ ‡9 [A-Z]+<KEEP>/, '');
+      tmp = tmp.replace(/ ‡9 [A-Z]+<KEEP>/u, '');
+      deletableStringsArray.push(tmp);
+    }
+
+    //  MET-461:
+    if (['245', '246'].includes(field.tag) && finishedRecord && fieldAsString.match(/ ‡a /u)) {
+      tmp = fieldAsString;
+      tmp = tmp.replace(/^(...) ../u, '946 ##'); // Ind
+      tmp = tmp.replace(" ‡a ", " ‡i Nimeke Onixissa: ‡a ");
+      tmp = tmp.replace(/ \/ ‡c[^‡]+$/u, ''); // Can $c be non-last?
+      deletableStringsArray.push(tmp);
+      if (field.tag === '245' && tmp.match(/\.$/u)) {
+        tmp = tmp.replace(/\.$/u, '');
+        deletableStringsArray.push(tmp);
+      }
+    }
+
+    // MRA-433-ish (non-chain): 490 ind1=1 vs ind1=0: remove latter
+    if (fieldAsString.match(/^490 1/) ) {
+      tmp = fieldAsString.replace(/^490 1/u, '490 0');
       deletableStringsArray.push(tmp);
     }
   }
+
   /* eslint-enable */
   return deletableStringsArray; // we should do uniq!
 

--- a/src/sortSubfields.js
+++ b/src/sortSubfields.js
@@ -52,7 +52,8 @@ export default function () {
 
 
 // X00, X10, X11 and X130 could also for their own sets...
-const sortOrderForX10 = ['6', 'a', 'b', 't', 'n', 'e', 'v', 'w', '0', '5', '9']; // somewhat iffy
+const sortOrderForX00 = ['6', 'i', 'a', 'b', 'c', 'q', 'd', 'e', 't', 'u', 'l', 'f', 'x', 'y', 'z', '0', '5', '9']; // skip $g. Can't remember why, though...
+const sortOrderForX10 = ['6', 'i', 'a', 'b', 't', 'n', 'e', 'v', 'w', 'x', 'y', 'z', '0', '5', '9']; // somewhat iffy
 const sortOrderFor7XX = ['8', '6', '7', 'i', 'a', 's', 't', 'b', 'c', 'd', 'm', 'h', 'k', 'o', 'x', 'z', 'g', 'q', 'w'];
 const sortOrderFor246 = ['i', 'a', 'b', 'n', 'p', 'f', '5', '9']; // Used by field 946 as well
 
@@ -64,7 +65,7 @@ const subfieldSortOrder = [
   {'tag': '040', 'sortOrder': ['8', '6', 'a', 'b', 'e', 'c', 'd', 'x']},
   {'tag': '041', 'sortOrder': ['8', '6', 'a', 'd', 'j', 'p', 'h', 'e', 'g', 'm']}, // guesswork
   {'tag': '048', 'sortOrder': ['8', '6', 'b', 'a']},
-  {'tag': '100', 'sortOrder': ['6', 'a', 'b', 'c', 'q', 'd', 'e', 'j', 't', 'u', 'l', 'f', '0', '5', '9']}, // don't do $g
+  {'tag': '100', 'sortOrder': sortOrderForX00},
   {'tag': '110', 'sortOrder': sortOrderForX10},
   {'tag': '111', 'sortOrder': ['a', 'n', 'd', 'c', 'e', 'g', 'j']},
   {'tag': '130', 'sortOrder': ['a', 'n', 'p', 'k', 'l']},
@@ -78,10 +79,11 @@ const subfieldSortOrder = [
   {'tag': '505', 'sortOrder': ['a']},
   {'tag': '526', 'sortOrder': ['i', 'a', 'b', 'x', 'z']},
   {'tag': '540', 'sortOrder': ['a', 'b', 'c', 'd', 'f', '2', 'u']},
-  {'tag': '600', 'sortOrder': ['6', 'a', 'b', 'c', 'q', 'd', 'e', '0', '5', '9']},
+  {'tag': '600', 'sortOrder': sortOrderForX00},
   {'tag': '610', 'sortOrder': sortOrderForX10},
   {'tag': '611', 'sortOrder': ['a', 'n', 'd', 'c', 'e', 'g', 'j']},
-  {'tag': '700', 'sortOrder': ['6', 'i', 'a', 'b', 'c', 'q', 'd', 'e', 't', 'u', 'l', 'f', '0', '5', '9']},
+  {'tag': '650', 'sortOrder': ['a', 'x', 'y', 'z']},
+  {'tag': '700', 'sortOrder': sortOrderForX00},
   {'tag': '710', 'sortOrder': sortOrderForX10},
   {'tag': '711', 'sortOrder': ['a', 'n', 'd', 'c', 'e', 'g', 'j']},
   {'tag': '760', 'sortOrder': sortOrderFor7XX},
@@ -100,7 +102,7 @@ const subfieldSortOrder = [
   {'tag': '786', 'sortOrder': sortOrderFor7XX},
   {'tag': '787', 'sortOrder': sortOrderFor7XX},
   {'tag': '788', 'sortOrder': sortOrderFor7XX},
-  {'tag': '800', 'sortOrder': ['i', 'a', 'b', 'c', 'q', 'd', 'e', 't', 'u', 'v', 'l', 'f', '0', '5', '9']},
+  {'tag': '800', 'sortOrder': sortOrderForX00},
   {'tag': '810', 'sortOrder': sortOrderForX10},
   {'tag': '811', 'sortOrder': ['a', 'n', 'd', 'c', 'e', 'g', 'j']},
   {'tag': '830', 'sortOrder': ['a', 'n', 'x', 'v']}, // INCOMPLETE, SAME AS 490? APPARENTLY NOT...
@@ -116,7 +118,7 @@ function getSubfieldSortOrder(field) {
     debugDev(`sort order for ${field.tag}: ${entry[0].sortOrder}`);
     return entry[0].sortOrder;
   }
-  nvdebug(`NO DROPPABLE SUBFIELDS FOUND FOR ${field.tag}.`);
+  nvdebug(`WARNING!\tNo subfield order found for ${field.tag}.`);
   return [];
 }
 
@@ -195,11 +197,11 @@ export function sortAdjacentSubfields(field, externalSortOrder = []) {
 
   const defaultSortOrder = finnishWay ? defaultSortOrderFinns : defaultSortOrderOthers; // $2 vs $0
   const subfieldOrder = sortOrderForField.length > 0 ? sortOrderForField : defaultSortOrder;
-  nvdebug(`FINAL SUBFIELD ORDER (FINNISH=${finnishWay}) FOR ${field.tag}: ${subfieldOrder.join(', ')}`);
+  //nvdebug(`FINAL SUBFIELD ORDER (FINNISH=${finnishWay}) FOR ${field.tag}: ${subfieldOrder.join(', ')}`);
   //if (sortOrder === null) { return field; } //// Currently always sort..
-  nvdebug(`IN:  ${fieldToString(field)}`);
+  //nvdebug(`IN:  ${fieldToString(field)}`);
   swapSubfields(field, subfieldOrder);
-  nvdebug(`OUT: ${fieldToString(field)}`);
+  //nvdebug(`OUT: ${fieldToString(field)}`);
 
   return field;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -54,3 +54,10 @@ export function fieldsToString(fields) {
 export function nvdebugFieldArray(fields, prefix = '  ', func = undefined) {
   fields.forEach(field => nvdebug(`${prefix}${fieldToString(field)}`, func));
 }
+
+export function isControlSubfieldCode(subfieldCode) {
+  if (['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'w'].includes(subfieldCode)) {
+    return true;
+  }
+  return false;
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -50,3 +50,7 @@ export function fieldToString(f) {
 export function fieldsToString(fields) {
   return fields.map(f => fieldToString(f)).join('\t__SEPARATOR__\t');
 }
+
+export function nvdebugFieldArray(fields, prefix = '  ', func = undefined) {
+  fields.forEach(field => nvdebug(`${prefix}${fieldToString(field)}`, func));
+}

--- a/test-fixtures/normalize-subfield-value/01/expectedResult.json
+++ b/test-fixtures/normalize-subfield-value/01/expectedResult.json
@@ -1,6 +1,8 @@
 {
   "message": [
     "'100 1# ‡a Sukunimi, A.B., ‡e kirjoittaja.' requires subfield internal mods/normalization",
+    "'700 1# ‡a Sukunimi, A.B.C., ‡e kirjoittaja.' requires subfield internal mods/normalization",
+    "'700 1# ‡a Sukunimelä, A.B. Cecilia' requires subfield internal mods/normalization",
     "'700 1# ‡a Sukunimelä, A.B.' requires subfield internal mods/normalization",
     "'730 ## ‡a Movie (elokuva, 2020)' requires subfield internal mods/normalization"
   ],

--- a/test-fixtures/normalize-subfield-value/01/record.json
+++ b/test-fixtures/normalize-subfield-value/01/record.json
@@ -16,10 +16,14 @@
       ]
     },
     { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
-      { "code": "a", "value": "Sukunimelä, A.B." }
+      { "code": "a", "value": "Sukunimelä, A.B. Cecilia" }
     ]},
     { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
-      { "code": "a", "value": "Sukunimelä, A.B.C." }
+      { "code": "a", "value": "Sukunimelä, A.B." }
+      ]
+    },
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Kaikki, O. N. Oikein." }
       ]
     },
     { "tag": "730", "ind1": " ", "ind2": " ", "subfields": [

--- a/test-fixtures/normalize-subfield-value/02/expectedResult.json
+++ b/test-fixtures/normalize-subfield-value/02/expectedResult.json
@@ -12,7 +12,7 @@
       { "code": "0", "value": "(FI-ASTERI-N)007654321"}
     ]},
     { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
-      { "code": "a", "value": "Sukunimi, A.B.C.," },
+      { "code": "a", "value": "Sukunimi, A. B. C.," },
       { "code": "e", "value": "kirjoittaja." }
       ]
     },
@@ -20,7 +20,7 @@
       { "code": "a", "value": "Sukunimelä, A. B." }
     ]},
     { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
-      { "code": "a", "value": "Sukunimelä, A.B.C." }
+      { "code": "a", "value": "Sukunimelä, A. B. C." }
       ]
     },
     { "tag": "730", "ind1": " ", "ind2": " ", "subfields": [

--- a/test-fixtures/remove-inferior-datafields/f02a/expectedResult.json
+++ b/test-fixtures/remove-inferior-datafields/f02a/expectedResult.json
@@ -1,0 +1,15 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+        { "code": "6", "value": "880-01"},
+        { "code": "a", "value": "Sukunimi, Etunimi."}
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "100-01/(B"},
+      { "code": "a", "value": "Sukunimi, Etunimi kiinaksi."}
+    ]}
+  ],
+  "leader": ""
+}

--- a/test-fixtures/remove-inferior-datafields/f02a/metadata.json
+++ b/test-fixtures/remove-inferior-datafields/f02a/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "f02a: MET-467-ish (better 100, supposed to work already)",
+  "enabled": true,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/remove-inferior-datafields/f02a/record.json
+++ b/test-fixtures/remove-inferior-datafields/f02a/record.json
@@ -1,0 +1,25 @@
+{
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+        { "code": "6", "value": "880-01"},
+        { "code": "a", "value": "Sukunimi, Etunimi."}
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-02"},
+      { "code": "a", "value": "Sukunimi, Etunimi."}
+    ]},
+
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "100-01/(B"},
+      { "code": "a", "value": "Sukunimi, Etunimi kiinaksi."}
+    ]},
+
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "700-02"},
+      { "code": "a", "value": "Sukunimi, Etunimi kiinaksi."}
+    ]}
+
+  ],
+  "leader": ""
+}

--- a/test-fixtures/remove-inferior-datafields/f02b/expectedResult.json
+++ b/test-fixtures/remove-inferior-datafields/f02b/expectedResult.json
@@ -1,0 +1,15 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+        { "code": "6", "value": "880-02"},
+        { "code": "a", "value": "Sukunimi, Etunimi."}
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "100-02/(B"},
+      { "code": "a", "value": "Sukunimi, Etunimi kiinaksi."}
+    ]}
+  ],
+  "leader": ""
+}

--- a/test-fixtures/remove-inferior-datafields/f02b/metadata.json
+++ b/test-fixtures/remove-inferior-datafields/f02b/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "f02b: MET-467 (better 700 replaces worse 100)",
+  "enabled": true,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/remove-inferior-datafields/f02b/record.json
+++ b/test-fixtures/remove-inferior-datafields/f02b/record.json
@@ -1,0 +1,25 @@
+{
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+        { "code": "6", "value": "880-01"},
+        { "code": "a", "value": "Sukunimi, Etunimi."}
+    ]},
+    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-02"},
+      { "code": "a", "value": "Sukunimi, Etunimi."}
+    ]},
+
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "100-01"},
+      { "code": "a", "value": "Sukunimi, Etunimi kiinaksi."}
+    ]},
+
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "700-02/(B"},
+      { "code": "a", "value": "Sukunimi, Etunimi kiinaksi."}
+    ]}
+
+  ],
+  "leader": ""
+}

--- a/test-fixtures/remove-inferior-datafields/f05/expectedResult.json
+++ b/test-fixtures/remove-inferior-datafields/f05/expectedResult.json
@@ -2,11 +2,8 @@
   "_validationOptions": {},
   "fields": [
     { "tag": "001", "value": "f01" },
+
     { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
-      { "code": "6", "value": "880-01"},
-      { "code": "a", "value": "Qu, Mi."}
-    ]},
-    { "tag": "700", "ind1": "1", "ind2": " ", "subfields": [
       { "code": "6", "value": "880-02"},
       { "code": "a", "value": "Qu, Mi."}
     ]},
@@ -15,11 +12,7 @@
       { "code": "a", "value": "Foo, Bar."}
     ]},
     { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
-      { "code": "6", "value": "100-01"},
-      { "code": "a", "value": "Uq, Im."}
-    ]},
-    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
-      { "code": "6", "value": "700-02/(N"},
+      { "code": "6", "value": "100-02/(N"},
       { "code": "a", "value": "Uq, Im."}
     ]},
     { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [

--- a/test-fixtures/remove-inferior-datafields/f07a/expectedResult.json
+++ b/test-fixtures/remove-inferior-datafields/f07a/expectedResult.json
@@ -1,0 +1,46 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "245", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "foo :"},
+      { "code": "b", "value": "bar /"},
+      { "code": "c", "value": "Kerho Ukkonen."}
+    ]},
+    { "tag": "246", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Ukkossanomat"}
+    ]},
+    { "tag": "246", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Ukkosenjumala"}
+    ]},
+
+    { "tag": "946", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "i", "value": "Nimeke Onixissa:"},
+      { "code": "a", "value": "foo :"},
+      { "code": "b", "value": "bar"}
+    ]},
+
+    { "tag": "946", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "i", "value": "Nimeke Onixissa:"},
+      { "code": "a", "value": "what :"},
+      { "code": "b", "value": "ever"}
+    ]},
+
+    { "tag": "946", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "i", "value": "Nimeke Onixissa:"},
+      { "code": "a", "value": "Ukkossanomat"}
+    ]},
+
+    { "tag": "946", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "i", "value": "Nimeke Onixissa:"},
+      { "code": "a", "value": "Ukkosenjumala"}
+    ]},
+
+    { "tag": "946", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "i", "value": "Nimeke Onixissa:"},
+      { "code": "a", "value": "Akkasenjumala"}
+    ]}
+  ],
+  "leader": "01331cam a22003498i 4500"
+
+}

--- a/test-fixtures/remove-inferior-datafields/f07a/metadata.json
+++ b/test-fixtures/remove-inferior-datafields/f07a/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "f07a: MET-461: fields are not deleted, as this a prepublication (LDR/17)",
+  "enabled": true,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/remove-inferior-datafields/f07a/record.json
+++ b/test-fixtures/remove-inferior-datafields/f07a/record.json
@@ -1,0 +1,45 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "245", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "foo :"},
+      { "code": "b", "value": "bar /"},
+      { "code": "c", "value": "Kerho Ukkonen."}
+    ]},
+    { "tag": "246", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Ukkossanomat"}
+    ]},
+    { "tag": "246", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Ukkosenjumala"}
+    ]},
+
+    { "tag": "946", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "i", "value": "Nimeke Onixissa:"},
+      { "code": "a", "value": "foo :"},
+      { "code": "b", "value": "bar"}
+    ]},
+
+    { "tag": "946", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "i", "value": "Nimeke Onixissa:"},
+      { "code": "a", "value": "what :"},
+      { "code": "b", "value": "ever"}
+    ]},
+
+    { "tag": "946", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "i", "value": "Nimeke Onixissa:"},
+      { "code": "a", "value": "Ukkossanomat"}
+    ]},
+
+    { "tag": "946", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "i", "value": "Nimeke Onixissa:"},
+      { "code": "a", "value": "Ukkosenjumala"}
+    ]},
+
+    { "tag": "946", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "i", "value": "Nimeke Onixissa:"},
+      { "code": "a", "value": "Akkasenjumala"}
+    ]}
+  ],
+  "leader": "01331cam a22003498i 4500"
+}

--- a/test-fixtures/remove-inferior-datafields/f07b/expectedResult.json
+++ b/test-fixtures/remove-inferior-datafields/f07b/expectedResult.json
@@ -1,0 +1,30 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "245", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "foo :"},
+      { "code": "b", "value": "bar /"},
+      { "code": "c", "value": "Kerho Ukkonen."}
+    ]},
+    { "tag": "246", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Ukkossanomat"}
+    ]},
+    { "tag": "246", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Ukkosenjumala"}
+    ]},
+
+    { "tag": "946", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "i", "value": "Nimeke Onixissa:"},
+      { "code": "a", "value": "what :"},
+      { "code": "b", "value": "ever"}
+    ]},
+
+    { "tag": "946", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "i", "value": "Nimeke Onixissa:"},
+      { "code": "a", "value": "Akkasenjumala"}
+    ]}
+  ],
+  "leader": "01331cam a22003494i 4500"
+
+}

--- a/test-fixtures/remove-inferior-datafields/f07b/metadata.json
+++ b/test-fixtures/remove-inferior-datafields/f07b/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "f07b: MET-461: remove 946 fields if they match with 245 or 246 fields",
+  "enabled": true,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/remove-inferior-datafields/f07b/record.json
+++ b/test-fixtures/remove-inferior-datafields/f07b/record.json
@@ -1,0 +1,45 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "245", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "foo :"},
+      { "code": "b", "value": "bar /"},
+      { "code": "c", "value": "Kerho Ukkonen."}
+    ]},
+    { "tag": "246", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Ukkossanomat"}
+    ]},
+    { "tag": "246", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Ukkosenjumala"}
+    ]},
+
+    { "tag": "946", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "i", "value": "Nimeke Onixissa:"},
+      { "code": "a", "value": "foo :"},
+      { "code": "b", "value": "bar"}
+    ]},
+
+    { "tag": "946", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "i", "value": "Nimeke Onixissa:"},
+      { "code": "a", "value": "what :"},
+      { "code": "b", "value": "ever"}
+    ]},
+
+    { "tag": "946", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "i", "value": "Nimeke Onixissa:"},
+      { "code": "a", "value": "Ukkossanomat"}
+    ]},
+
+    { "tag": "946", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "i", "value": "Nimeke Onixissa:"},
+      { "code": "a", "value": "Ukkosenjumala"}
+    ]},
+
+    { "tag": "946", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "i", "value": "Nimeke Onixissa:"},
+      { "code": "a", "value": "Akkasenjumala"}
+    ]}
+  ],
+  "leader": "01331cam a22003494i 4500"
+}

--- a/test-fixtures/remove-inferior-datafields/f07c/expectedResult.json
+++ b/test-fixtures/remove-inferior-datafields/f07c/expectedResult.json
@@ -1,0 +1,28 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "245", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "foo :"},
+      { "code": "b", "value": "bar /"},
+      { "code": "c", "value": "Kerho Ukkonen."}
+    ]},
+    { "tag": "246", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Ukkossanomat"}
+    ]},
+    { "tag": "246", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Ukkosenjumala"}
+    ]},
+
+    { "tag": "946", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "foo :"},
+      { "code": "b", "value": "bar"}
+    ]},
+
+    { "tag": "946", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Ukkossanomat"}
+    ]}
+
+  ],
+  "leader": "01331cam a22003494i 4500"
+}

--- a/test-fixtures/remove-inferior-datafields/f07c/metadata.json
+++ b/test-fixtures/remove-inferior-datafields/f07c/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "f07b: MET-461: keep values that don't have $i 'Nimeke Onixissa:'",
+  "enabled": true,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/remove-inferior-datafields/f07c/metadata.json
+++ b/test-fixtures/remove-inferior-datafields/f07c/metadata.json
@@ -1,5 +1,5 @@
 {
-  "description": "f07b: MET-461: keep values that don't have $i 'Nimeke Onixissa:'",
+  "description": "f07c: MET-461: keep values that don't have $i 'Nimeke Onixissa:'",
   "enabled": true,
   "fix": true,
   "only": false

--- a/test-fixtures/remove-inferior-datafields/f07c/record.json
+++ b/test-fixtures/remove-inferior-datafields/f07c/record.json
@@ -1,0 +1,32 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "245", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "foo :"},
+      { "code": "b", "value": "bar /"},
+      { "code": "c", "value": "Kerho Ukkonen."}
+    ]},
+    { "tag": "246", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Ukkossanomat"}
+    ]},
+    { "tag": "246", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Ukkosenjumala"}
+    ]},
+
+    { "tag": "946", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "foo :"},
+      { "code": "b", "value": "bar"}
+    ]},
+
+    { "tag": "946", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "Ukkossanomat"}
+    ]},
+
+    { "tag": "946", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "i", "value": "Nimeke Onixissa:"},
+      { "code": "a", "value": "Ukkosenjumala"}
+    ]}
+  ],
+  "leader": "01331cam a22003494i 4500"
+}

--- a/test-fixtures/remove-inferior-datafields/f07d/expectedResult.json
+++ b/test-fixtures/remove-inferior-datafields/f07d/expectedResult.json
@@ -1,0 +1,11 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "245", "ind1": "1", "ind2": "0", "subfields": [
+      { "code": "a", "value": "Kookosta, komisario Palmu /"},
+      { "code": "c", "value": "Laku Panda."}
+    ]}
+  ],
+  "leader": "01331cam a22003494i 4500"
+}

--- a/test-fixtures/remove-inferior-datafields/f07d/metadata.json
+++ b/test-fixtures/remove-inferior-datafields/f07d/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "f07d: MET-461 (comments): 946$ does not prevent field deletion'",
+  "enabled": true,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/remove-inferior-datafields/f07d/record.json
+++ b/test-fixtures/remove-inferior-datafields/f07d/record.json
@@ -1,0 +1,16 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "245", "ind1": "1", "ind2": "0", "subfields": [
+      { "code": "a", "value": "Kookosta, komisario Palmu /"},
+      { "code": "c", "value": "Laku Panda."}
+    ]},
+    { "tag": "946", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "i", "value": "Nimeke Onixissa :"},
+      { "code": "a", "value": "Kookosta, komisario Palmu"},
+      { "code": "5", "value": "MELINDA"}
+    ]}
+  ],
+  "leader": "01331cam a22003494i 4500"
+}

--- a/test-fixtures/remove-inferior-datafields/f07e/expectedResult.json
+++ b/test-fixtures/remove-inferior-datafields/f07e/expectedResult.json
@@ -1,0 +1,13 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "245", "ind1": "1", "ind2": "0", "subfields": [
+      { "code": "a", "value": "Entinen elämäni! :"},
+      { "code": "b", "value": "Transylvanialainen klassismi."},
+      { "code": "n", "value": "II /"},
+      { "code": "c", "value": "Kreivi Dracula; käännös: Renfield."}
+    ]}
+  ],
+  "leader": "01331cam a22003494i 4500"
+}

--- a/test-fixtures/remove-inferior-datafields/f07e/metadata.json
+++ b/test-fixtures/remove-inferior-datafields/f07e/metadata.json
@@ -1,0 +1,7 @@
+{
+  "description": "f07e: MET-461 (comments): 946$ does not prevent field deletion'",
+  "comment": "2023-08-31: Not relevant here, but note that '!' is currently retained in normalization. Not sure if it's a bug or a feature. Or good or bad...",
+  "enabled": true,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/remove-inferior-datafields/f07e/record.json
+++ b/test-fixtures/remove-inferior-datafields/f07e/record.json
@@ -1,0 +1,20 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "245", "ind1": "1", "ind2": "0", "subfields": [
+      { "code": "a", "value": "Entinen elämäni! :"},
+      { "code": "b", "value": "Transylvanialainen klassismi."},
+      { "code": "n", "value": "II /"},
+      { "code": "c", "value": "Kreivi Dracula; käännös: Renfield."}
+    ]},
+    { "tag": "946", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "i", "value": "Nimeke Onixissa :"},
+      { "code": "a", "value": "Entinen elämäni!"},
+      { "code": "b", "value": "Transylvanialainen klassismi"},
+      { "code": "n", "value": "II"},
+      { "code": "5", "value": "MELINDA"}
+    ]}
+  ],
+  "leader": "01331cam a22003494i 4500"
+}

--- a/test-fixtures/remove-inferior-datafields/f07f/expectedResult.json
+++ b/test-fixtures/remove-inferior-datafields/f07f/expectedResult.json
@@ -1,0 +1,12 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "245", "ind1": "1", "ind2": "0", "subfields": [
+      { "code": "a", "value": "Isokyröläisten murheet :"},
+      { "code": "b", "value": "hutkimus keskiajalta 1900-luvulle /"},
+      { "code": "c", "value": "Rontti Tulipalo."}
+    ]}
+  ],
+  "leader": "01331cam a22003494i 4500"
+}

--- a/test-fixtures/remove-inferior-datafields/f07f/metadata.json
+++ b/test-fixtures/remove-inferior-datafields/f07f/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "f07f: MET-461 (comments): case difference does not prevent field deletion (reason: normalization)",
+  "enabled": true,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/remove-inferior-datafields/f07f/record.json
+++ b/test-fixtures/remove-inferior-datafields/f07f/record.json
@@ -1,0 +1,18 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "245", "ind1": "1", "ind2": "0", "subfields": [
+      { "code": "a", "value": "Isokyröläisten murheet :"},
+      { "code": "b", "value": "hutkimus keskiajalta 1900-luvulle /"},
+      { "code": "c", "value": "Rontti Tulipalo."}
+    ]},
+    { "tag": "946", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "i", "value": "Nimeke Onixissa :"},
+      { "code": "a", "value": "Isokyröläisten murheet"},
+      { "code": "b", "value": "Hutkimus keskiajalta 1900-luvulle"},
+      { "code": "5", "value": "MELINDA"}
+    ]}
+  ],
+  "leader": "01331cam a22003494i 4500"
+}

--- a/test-fixtures/remove-inferior-datafields/f07g/expectedResult.json
+++ b/test-fixtures/remove-inferior-datafields/f07g/expectedResult.json
@@ -1,0 +1,19 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "245", "ind1": "1", "ind2": "0", "subfields": [
+      { "code": "a", "value": "Haavi auki :"},
+      { "code": "b", "value": "työskentelyä Ankalliskirjastossa."},
+      { "code": "n", "value": "II /"},
+      { "code": "c", "value": "toimittajat: T. Puominen ja T. Eestiläinen."}
+    ]},
+    { "tag": "946", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "i", "value": "Nimeke Onixissa :"},
+      { "code": "a", "value": "Haavi auki II"},
+      { "code": "b", "value": "Työskentelyä Ankalliskirjastossa"},
+      { "code": "5", "value": "MELINDA"}
+    ]}
+  ],
+  "leader": "01331cam a22003494i 4500"
+}

--- a/test-fixtures/remove-inferior-datafields/f07g/metadata.json
+++ b/test-fixtures/remove-inferior-datafields/f07g/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "f07g: MET-461 (comments): different subfielding prevents removal",
+  "enabled": true,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/remove-inferior-datafields/f07g/record.json
+++ b/test-fixtures/remove-inferior-datafields/f07g/record.json
@@ -1,0 +1,19 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "245", "ind1": "1", "ind2": "0", "subfields": [
+      { "code": "a", "value": "Haavi auki :"},
+      { "code": "b", "value": "työskentelyä Ankalliskirjastossa."},
+      { "code": "n", "value": "II /"},
+      { "code": "c", "value": "toimittajat: T. Puominen ja T. Eestiläinen."}
+    ]},
+    { "tag": "946", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "i", "value": "Nimeke Onixissa :"},
+      { "code": "a", "value": "Haavi auki II"},
+      { "code": "b", "value": "Työskentelyä Ankalliskirjastossa"},
+      { "code": "5", "value": "MELINDA"}
+    ]}
+  ],
+  "leader": "01331cam a22003494i 4500"
+}

--- a/test-fixtures/remove-inferior-datafields/f07h/expectedResult.json
+++ b/test-fixtures/remove-inferior-datafields/f07h/expectedResult.json
@@ -1,0 +1,27 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "245", "ind1": "1", "ind2": "0", "subfields": [
+      { "code": "a", "value": "Haisteluni."},
+      { "code": "n", "value": "VII /"},
+      { "code": "c", "value": "Vihikoira Vuh."}
+    ]},
+    { "tag": "246", "ind1": "1", "ind2": "4", "subfields": [
+      { "code": "a", "value": "Haisteluni."},
+      { "code": "n", "value": "Seitsemäs kirja"}
+    ]},
+    { "tag": "246", "ind1": "1", "ind2": "4", "subfields": [
+      { "code": "a", "value": "Haisteluni."},
+      { "code": "n", "value": "7"}
+    ]},
+
+    { "tag": "946", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "i", "value": "Nimeke Onixissa:"},
+      { "code": "a", "value": "Haisteluni"},
+      { "code": "b", "value": "Seitsemäs kirja"},
+      { "code": "5", "value": "MELINDA"}
+    ]}
+  ],
+  "leader": "01331cam a22003494i 4500"
+}

--- a/test-fixtures/remove-inferior-datafields/f07h/metadata.json
+++ b/test-fixtures/remove-inferior-datafields/f07h/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "f07h: MET-461 (comments): subfield code difference prevents field 946 removal",
+  "enabled": true,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/remove-inferior-datafields/f07h/record.json
+++ b/test-fixtures/remove-inferior-datafields/f07h/record.json
@@ -1,0 +1,27 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "245", "ind1": "1", "ind2": "0", "subfields": [
+      { "code": "a", "value": "Haisteluni."},
+      { "code": "n", "value": "VII /"},
+      { "code": "c", "value": "Vihikoira Vuh."}
+    ]},
+    { "tag": "246", "ind1": "1", "ind2": "4", "subfields": [
+      { "code": "a", "value": "Haisteluni."},
+      { "code": "n", "value": "Seitsemäs kirja"}
+    ]},
+    { "tag": "246", "ind1": "1", "ind2": "4", "subfields": [
+      { "code": "a", "value": "Haisteluni."},
+      { "code": "n", "value": "7"}
+    ]},
+
+    { "tag": "946", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "i", "value": "Nimeke Onixissa:"},
+      { "code": "a", "value": "Haisteluni"},
+      { "code": "b", "value": "Seitsemäs kirja"},
+      { "code": "5", "value": "MELINDA"}
+    ]}
+  ],
+  "leader": "01331cam a22003494i 4500"
+}

--- a/test-fixtures/remove-inferior-datafields/f07i/expectedResult.json
+++ b/test-fixtures/remove-inferior-datafields/f07i/expectedResult.json
@@ -1,0 +1,20 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "245", "ind1": "1", "ind2": "0", "subfields": [
+      { "code": "a", "value": "Haisteluni."},
+      { "code": "n", "value": "VII /"},
+      { "code": "c", "value": "Vihikoira Vuh."}
+    ]},
+    { "tag": "246", "ind1": "1", "ind2": "4", "subfields": [
+      { "code": "a", "value": "Haisteluni."},
+      { "code": "n", "value": "Seitsemäs kirja"}
+    ]},
+    { "tag": "246", "ind1": "1", "ind2": "4", "subfields": [
+      { "code": "a", "value": "Haisteluni."},
+      { "code": "n", "value": "7"}
+    ]}
+  ],
+  "leader": "01331cam a22003494i 4500"
+}

--- a/test-fixtures/remove-inferior-datafields/f07i/metadata.json
+++ b/test-fixtures/remove-inferior-datafields/f07i/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "f07i: MET-461 (derivate of comments): just a slightly more complex test for field 246",
+  "enabled": true,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/remove-inferior-datafields/f07i/record.json
+++ b/test-fixtures/remove-inferior-datafields/f07i/record.json
@@ -1,0 +1,27 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "245", "ind1": "1", "ind2": "0", "subfields": [
+      { "code": "a", "value": "Haisteluni."},
+      { "code": "n", "value": "VII /"},
+      { "code": "c", "value": "Vihikoira Vuh."}
+    ]},
+    { "tag": "246", "ind1": "1", "ind2": "4", "subfields": [
+      { "code": "a", "value": "Haisteluni."},
+      { "code": "n", "value": "Seitsemäs kirja"}
+    ]},
+    { "tag": "246", "ind1": "1", "ind2": "4", "subfields": [
+      { "code": "a", "value": "Haisteluni."},
+      { "code": "n", "value": "7"}
+    ]},
+
+    { "tag": "946", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "i", "value": "Nimeke Onixissa:"},
+      { "code": "a", "value": "Haisteluni"},
+      { "code": "n", "value": "Seitsemäs kirja"},
+      { "code": "5", "value": "MELINDA"}
+    ]}
+  ],
+  "leader": "01331cam a22003494i 4500"
+}

--- a/test-fixtures/remove-inferior-datafields/f08/expectedResult.json
+++ b/test-fixtures/remove-inferior-datafields/f08/expectedResult.json
@@ -1,0 +1,22 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "490", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01"},
+      { "code": "a", "value": "eka sarjan nimi"}
+    ]},
+    { "tag": "490", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "toka sarjan nimi"}
+    ]},
+
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "490-01"},
+      { "code": "a", "value": "eka sarjan nimi toisella aakkostolla"}
+    ]}
+
+
+  ],
+  "leader": "01331cam a22003498i 4500"
+
+}

--- a/test-fixtures/remove-inferior-datafields/f08/metadata.json
+++ b/test-fixtures/remove-inferior-datafields/f08/metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "f08/MRA-433: ind1=0 can be removed",
+  "enabled": true,
+  "fix": true,
+  "only": false
+}

--- a/test-fixtures/remove-inferior-datafields/f08/record.json
+++ b/test-fixtures/remove-inferior-datafields/f08/record.json
@@ -1,0 +1,33 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "001", "value": "f01" },
+    { "tag": "490", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01"},
+      { "code": "a", "value": "eka sarjan nimi"}
+    ]},
+    { "tag": "490", "ind1": "0", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-02"},
+      { "code": "a", "value": "eka sarjan nimi"}
+    ]},
+    { "tag": "490", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "a", "value": "toka sarjan nimi"}
+    ]},
+    { "tag": "490", "ind1": "0", "ind2": " ", "subfields": [
+      { "code": "a", "value": "toka sarjan nimi"}
+    ]},
+
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "490-01"},
+      { "code": "a", "value": "eka sarjan nimi toisella aakkostolla"}
+    ]},
+    { "tag": "880", "ind1": "0", "ind2": " ", "subfields": [
+      { "code": "6", "value": "490-02"},
+      { "code": "a", "value": "eka sarjan nimi toisella aakkostolla"}
+    ]}
+
+
+  ],
+  "leader": "01331cam a22003498i 4500"
+
+}

--- a/test-fixtures/sort-subfields/f01/expectedResult.json
+++ b/test-fixtures/sort-subfields/f01/expectedResult.json
@@ -15,7 +15,11 @@
       {"code": "e", "value": "kustantaja,"},
       {"code": "e", "value": "kustanantaja."},
       {"code": "0", "value": "(FI-ASTERI-N)000111222"}
-
+    ]},
+    { "tag": "946", "ind1": " ", "ind2": " ",  "subfields": [
+      { "code": "i", "value": "Nimeke Onixissa:" },
+      { "code": "a", "value": "whatever" },
+      { "code": "5", "value": "FOOBAR" }
     ]}
 
 

--- a/test-fixtures/sort-subfields/f01/record.json
+++ b/test-fixtures/sort-subfields/f01/record.json
@@ -14,6 +14,11 @@
       {"code": "e", "value": "kustantaja,"},
       {"code": "0", "value": "(FI-ASTERI-N)000111222"},
       {"code": "e", "value": "kustanantaja."}
+    ]},
+    { "tag": "946", "ind1": " ", "ind2": " ",  "subfields": [
+      { "code": "a", "value": "whatever" },
+      { "code": "5", "value": "FOOBAR" },
+      { "code": "i", "value": "Nimeke Onixissa:" }
     ]}
   ],
   "leader": ""


### PR DESCRIPTION
prePublicationUtils
* Move prepublicationUtils.js for handling different levels of prePublication records  here (was in marc-record-merger-reducers-js before)

subfieldValueNormalizations:
* Implement validator/fixer in subfieldValueNormalizations for adding spaces between initials in fX00 subfield $a (MRA-273)

sortSubfields
* Improve subfield order between subfields $2 and $0 (solves eg. part of by MRA-465)
* Support field 946 (MET-461)
* Extend subfield sort order for fields 246 and 946 

removeInferiorDatafields
* Support field 946 (MET-461)
* Improve handling f490 (MRA-433) ** If two otherwise identical 490 fields exist, keep the one with ind1=1 and drop the one with ind1=0. Both lone fields and chained fields are supported
* Improve handling fields 1XX/7XX (MET-467) ** Chain: if better 7XX fields exists, remove worse 1XX field, and re-tag 7XX as 1XX

punctuation2
* Add punctuation rules for fields 246 and 946 (MET-461)

* Update deps

* Reduce logging
* Add comments

* 10.12.0-alpha.3