### PR TITLE
Sanastobugi

### DIFF
--- a/src/indicator-fixes.js
+++ b/src/indicator-fixes.js
@@ -144,6 +144,24 @@ function normalizeNonFilingIndicator2(field, languages = []) {
   field.ind2 = determineNonFilingIndicatorValue(field, languages); // eslint-disable-line functional/immutable-data
 }
 
+const fiktiivisenAineistonLisaluokatFI = ['Eläimet', 'Erotiikka', 'Erä', 'Fantasia', 'Historia', 'Huumori', 'Jännitys', 'Kauhu', 'Novellit', 'Romantiikka', 'Scifi', 'Sota', 'Urheilu', 'Uskonto'];
+
+function containsFiktiivisenAineistonLisaluokka(field) {
+  // Should we check Swedish versions as well?
+  return field.subfields.some(sf => sf.code === 'a' && fiktiivisenAineistonLisaluokatFI.includes(sf.value));
+}
+
+function normalize084Indicator1(field) {
+  if (field.tag !== '084') {
+    return;
+  }
+
+  // https://marc21.kansalliskirjasto.fi/bib/05X-08X.htm#084 and https://finto.fi/ykl/fi/page/fiktioluokka
+  if (field.ind1 !== '9' && containsFiktiivisenAineistonLisaluokka(field) && field.subfields.some(sf => sf.code === '2' && sf.value === 'ykl')) {
+    field.ind1 = '9'; // eslint-disable-line functional/immutable-data
+    return;
+  }
+}
 
 function normalize245Indicator1(field, record) {
   if (field.tag !== '245') {
@@ -222,6 +240,7 @@ export function recordNormalizeIndicators(record) {
 }
 
 function fieldNormalizeIndicators(field, record, languages) {
+  normalize084Indicator1(field);
   normalize245Indicator1(field, record);
   normalizeNonFilingIndicator1(field, languages);
   normalizeNonFilingIndicator2(field, languages);

--- a/src/sanitize-vocabulary-source-codes.js
+++ b/src/sanitize-vocabulary-source-codes.js
@@ -88,6 +88,10 @@ function fieldHasUnfixableVocabularySourceCode(field) {
 }
 
 function subfieldHasUnfixableVocabularySourceCode(subfield) {
+  if (subfield.code !== '2') {
+    return false;
+  }
+
   // As we can't fix this here, apply this yso-rule only when validating!
   if (subfield.value.indexOf('yso/') === 0) {
     return !['yso/eng', 'yso/fin', 'yso/sme', 'yso/swe'].includes(subfield.value);

--- a/test-fixtures/indicator-fixes/09/expectedResult.json
+++ b/test-fixtures/indicator-fixes/09/expectedResult.json
@@ -1,0 +1,10 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "005", "value": "20220202020202.0" },
+    { "tag": "084", "ind1": " ", "ind2": " ", "subfields": [ {"code": "a", "value": "Whatever"}, {"code": "2", "value": "ykl"} ]},
+    { "tag": "084", "ind1": "9", "ind2": " ", "subfields": [ {"code": "a", "value": "Urheilu"}, {"code": "2", "value": "ykl"} ]},
+    { "tag": "084", "ind1": " ", "ind2": " ", "subfields": [ {"code": "a", "value": "Urheilu"}, {"code": "2", "value": "jokumuu"} ]}
+  ],
+  "leader": ""
+}

--- a/test-fixtures/indicator-fixes/09/metadata.json
+++ b/test-fixtures/indicator-fixes/09/metadata.json
@@ -1,0 +1,4 @@
+{
+  "description": "09: 084ind1=9 if ykl and $a belongs to Fiktiivisen aineiston lisäluokat",
+  "fix": true
+}

--- a/test-fixtures/indicator-fixes/09/record.json
+++ b/test-fixtures/indicator-fixes/09/record.json
@@ -1,0 +1,11 @@
+{
+  "_validationOptions": {},
+  "fields": [
+    { "tag": "005", "value": "20220202020202.0" },
+    { "tag": "084", "ind1": " ", "ind2": " ", "subfields": [ {"code": "a", "value": "Whatever"}, {"code": "2", "value": "ykl"} ]},
+    { "tag": "084", "ind1": " ", "ind2": " ", "subfields": [ {"code": "a", "value": "Urheilu"}, {"code": "2", "value": "ykl"} ]},
+    { "tag": "084", "ind1": " ", "ind2": " ", "subfields": [ {"code": "a", "value": "Urheilu"}, {"code": "2", "value": "jokumuu"} ]}
+
+  ],
+  "leader": ""
+}

--- a/test-fixtures/sanitize-vocabulary-source-codes/f04/expectedResult.json
+++ b/test-fixtures/sanitize-vocabulary-source-codes/f04/expectedResult.json
@@ -1,0 +1,74 @@
+{
+  "leader": "01470cam a22004214i 4500",
+  "_validationOptions": { },
+  "fields" : [
+    { "tag": "001", "value": "001173044" },
+    { "tag": "003", "value": "FI-MELINDA" },
+    { "tag": "005", "value": "20160810215731.0" },
+    { "tag": "008", "value": "880603s1978    gw |||||||||||||||||ger||" },
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "3-7613-0117-0" }
+    ]},
+    { "tag": "035", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "(FI-MELINDA)001173044" }
+    ]},
+    { "tag": "041", "ind1": "0", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "ger" }
+    ]},
+    { "tag": "050", "ind1": " ", "ind2": "4", "subfields" : [
+        { "code": "a", "value": "BX485" }
+    ]},
+    { "tag": "080", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "281.93:27" },
+        { "code": "x", "value": "(47)" }
+    ]},
+    { "tag": "080", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "281.93" }
+    ]},
+    { "tag": "080", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "27" },
+        { "code": "x", "value": "(47)" }
+    ]},
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "Immekus, Erwin." }
+    ]},
+    { "tag": "245", "ind1": "1", "ind2": "4", "subfields" : [
+        { "code": "a", "value": "Die russisch-orthodoxe Landpfarrei zu Beginn des XX. Jahrhunderts nach dem Gutachten der Diözesanbischöfe /" },
+        { "code": "c", "value": "Erwin Immekus." }
+    ]},
+    { "tag": "260", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "Würzburg :" },
+        { "code": "b", "value": "Augustinus-Verlag," },
+        { "code": "c", "value": "1978." }
+    ]},
+    { "tag": "300", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "xvi, 284 p. ;" },
+        { "code": "c", "value": "23 cm" }
+    ]},
+    { "tag": "336", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "teksti" },
+        { "code": "b", "value": "txt" },
+        { "code": "2", "value": "rdacontent" }
+    ]},
+    { "tag": "337", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "käytettävissä ilman laitetta" },
+        { "code": "b", "value": "n" },
+        { "code": "2", "value": "rdamedia" }
+    ]},
+    { "tag": "338", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "nide" },
+        { "code": "b", "value": "nc" },
+        { "code": "2", "value": "rdacarrier" }
+    ]},
+
+    { "tag": "655", "ind1": " ", "ind2": "7", "subfields" : [
+        { "code": "a", "value": "japaninkielinen kirjallisuus" },
+        { "code": "2", "value": "local" }
+    ]},
+    { "tag": "655", "ind1": " ", "ind2": "7", "subfields" : [
+        { "code": "a", "value": "käännökset" },
+        { "code": "2", "value": "slm/fin" },
+        { "code": "0" }
+    ]}
+  ]
+}

--- a/test-fixtures/sanitize-vocabulary-source-codes/f04/metadata.json
+++ b/test-fixtures/sanitize-vocabulary-source-codes/f04/metadata.json
@@ -1,0 +1,8 @@
+{
+  "description": "f04: bug fix 20240523 (JO/Slack): $0 with no value",
+  "fix": true,
+  "only": false,
+  "_validationOptions": {
+    "subfieldValues": false
+  }
+}

--- a/test-fixtures/sanitize-vocabulary-source-codes/f04/record.json
+++ b/test-fixtures/sanitize-vocabulary-source-codes/f04/record.json
@@ -1,0 +1,75 @@
+{
+  "leader": "01470cam a22004214i 4500",
+  "_validationOptions": {
+    "subfieldValues": false
+  },
+  "fields" : [
+    { "tag": "001", "value": "001173044" },
+    { "tag": "003", "value": "FI-MELINDA" },
+    { "tag": "005", "value": "20160810215731.0" },
+    { "tag": "008", "value": "880603s1978    gw |||||||||||||||||ger||" },
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "3-7613-0117-0" }
+    ]},
+    { "tag": "035", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "(FI-MELINDA)001173044" }
+    ]},
+    { "tag": "041", "ind1": "0", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "ger" }
+    ]},
+    { "tag": "050", "ind1": " ", "ind2": "4", "subfields" : [
+        { "code": "a", "value": "BX485" }
+    ]},
+    { "tag": "080", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "281.93:27" },
+        { "code": "x", "value": "(47)" }
+    ]},
+    { "tag": "080", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "281.93" }
+    ]},
+    { "tag": "080", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "27" },
+        { "code": "x", "value": "(47)" }
+    ]},
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "Immekus, Erwin." }
+    ]},
+    { "tag": "245", "ind1": "1", "ind2": "4", "subfields" : [
+        { "code": "a", "value": "Die russisch-orthodoxe Landpfarrei zu Beginn des XX. Jahrhunderts nach dem Gutachten der Diözesanbischöfe /" },
+        { "code": "c", "value": "Erwin Immekus." }
+    ]},
+    { "tag": "260", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "Würzburg :" },
+        { "code": "b", "value": "Augustinus-Verlag," },
+        { "code": "c", "value": "1978." }
+    ]},
+    { "tag": "300", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "xvi, 284 p. ;" },
+        { "code": "c", "value": "23 cm" }
+    ]},
+    { "tag": "336", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "teksti" },
+        { "code": "b", "value": "txt" },
+        { "code": "2", "value": "rdacontent" }
+    ]},
+    { "tag": "337", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "käytettävissä ilman laitetta" },
+        { "code": "b", "value": "n" },
+        { "code": "2", "value": "rdamedia" }
+    ]},
+    { "tag": "338", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "nide" },
+        { "code": "b", "value": "nc" },
+        { "code": "2", "value": "rdacarrier" }
+    ]},
+    { "tag": "655", "ind1": " ", "ind2": "7", "subfields" : [
+        { "code": "a", "value": "japaninkielinen kirjallisuus" },
+        { "code": "2", "value": "local" }
+    ]},
+    { "tag": "655", "ind1": " ", "ind2": "7", "subfields" : [
+        { "code": "a", "value": "käännökset" },
+        { "code": "2", "value": "slm/fin" },
+        { "code": "0" }
+    ]}
+  ]
+}

--- a/test-fixtures/sanitize-vocabulary-source-codes/v04/expectedResult.json
+++ b/test-fixtures/sanitize-vocabulary-source-codes/v04/expectedResult.json
@@ -1,0 +1,5 @@
+{
+  "message": [
+  ],
+  "valid": true
+}

--- a/test-fixtures/sanitize-vocabulary-source-codes/v04/metadata.json
+++ b/test-fixtures/sanitize-vocabulary-source-codes/v04/metadata.json
@@ -1,0 +1,8 @@
+{
+  "description": "v04: bug fix 20240523 (JO/Slack): $0 with no value",
+  "fix": false,
+  "only": false,
+  "_validationOptions": {
+    "subfieldValues": false
+  }
+}

--- a/test-fixtures/sanitize-vocabulary-source-codes/v04/record.json
+++ b/test-fixtures/sanitize-vocabulary-source-codes/v04/record.json
@@ -1,0 +1,75 @@
+{
+  "leader": "01470cam a22004214i 4500",
+  "_validationOptions": {
+    "subfieldValues": false
+  },
+  "fields" : [
+    { "tag": "001", "value": "001173044" },
+    { "tag": "003", "value": "FI-MELINDA" },
+    { "tag": "005", "value": "20160810215731.0" },
+    { "tag": "008", "value": "880603s1978    gw |||||||||||||||||ger||" },
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "3-7613-0117-0" }
+    ]},
+    { "tag": "035", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "(FI-MELINDA)001173044" }
+    ]},
+    { "tag": "041", "ind1": "0", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "ger" }
+    ]},
+    { "tag": "050", "ind1": " ", "ind2": "4", "subfields" : [
+        { "code": "a", "value": "BX485" }
+    ]},
+    { "tag": "080", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "281.93:27" },
+        { "code": "x", "value": "(47)" }
+    ]},
+    { "tag": "080", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "281.93" }
+    ]},
+    { "tag": "080", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "27" },
+        { "code": "x", "value": "(47)" }
+    ]},
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "Immekus, Erwin." }
+    ]},
+    { "tag": "245", "ind1": "1", "ind2": "4", "subfields" : [
+        { "code": "a", "value": "Die russisch-orthodoxe Landpfarrei zu Beginn des XX. Jahrhunderts nach dem Gutachten der Diözesanbischöfe /" },
+        { "code": "c", "value": "Erwin Immekus." }
+    ]},
+    { "tag": "260", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "Würzburg :" },
+        { "code": "b", "value": "Augustinus-Verlag," },
+        { "code": "c", "value": "1978." }
+    ]},
+    { "tag": "300", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "xvi, 284 p. ;" },
+        { "code": "c", "value": "23 cm" }
+    ]},
+    { "tag": "336", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "teksti" },
+        { "code": "b", "value": "txt" },
+        { "code": "2", "value": "rdacontent" }
+    ]},
+    { "tag": "337", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "käytettävissä ilman laitetta" },
+        { "code": "b", "value": "n" },
+        { "code": "2", "value": "rdamedia" }
+    ]},
+    { "tag": "338", "ind1": " ", "ind2": " ", "subfields" : [
+        { "code": "a", "value": "nide" },
+        { "code": "b", "value": "nc" },
+        { "code": "2", "value": "rdacarrier" }
+    ]},
+    { "tag": "655", "ind1": " ", "ind2": "7", "subfields" : [
+        { "code": "a", "value": "japaninkielinen kirjallisuus" },
+        { "code": "2", "value": "local" }
+    ]},
+    { "tag": "655", "ind1": " ", "ind2": "7", "subfields" : [
+        { "code": "a", "value": "käännökset" },
+        { "code": "2", "value": "slm/fin" },
+        { "code": "0" }
+    ]}
+  ]
+}


### PR DESCRIPTION
Fix a bug in sanitize-vocabulary-source.codes.js: look for vocabulary source codes only from subfield $2.