### PR TITLE
Melinda 10330 cyrillux chains

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,10 @@
         "@babel/register": "^7.24.6",
         "@natlibfi/issn-verify": "^1.0.4",
         "@natlibfi/marc-record": "^9.0.1",
-        "@natlibfi/marc-record-validate": "^8.0.8",
+        "@natlibfi/marc-record-validate": "^8.0.10",
         "cld3-asm": "^3.1.1",
         "clone": "^2.1.2",
-        "debug": "^4.3.4",
+        "debug": "^4.3.7",
         "isbn3": "^1.1.52",
         "iso9_1995": "^0.0.2",
         "langs": "^2.0.0",
@@ -29,8 +29,8 @@
         "@babel/core": "^7.24.7",
         "@babel/preset-env": "^7.25.4",
         "@natlibfi/eslint-config-melinda-backend": "^3.0.5",
-        "@natlibfi/fixugen": "^2.0.5",
-        "@natlibfi/fixura": "^3.0.5",
+        "@natlibfi/fixugen": "^2.0.9",
+        "@natlibfi/fixura": "^3.0.8",
         "babel-plugin-istanbul": "^7.0.0",
         "babel-plugin-rewire": "^1.2.0",
         "chai": "^4.5.0",
@@ -45,7 +45,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@natlibfi/marc-record-validate": "^8.0.7"
+        "@natlibfi/marc-record-validate": "^8.0.10"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2670,9 +2670,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001655",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001655.tgz",
-      "integrity": "sha512-jRGVy3iSGO5Uutn2owlb5gR6qsGngTw9ZTb4ali9f3glshcNmJ2noam4Mo9zia5P9Dk3jNNydy7vQjuE5dQmfg==",
+      "version": "1.0.30001660",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001660.tgz",
+      "integrity": "sha512-GacvNTTuATm26qC74pt+ad1fW15mlQ/zuTzzY1ZoIzECTP8HURDfF43kNxPgf7H1jmelCBQTTbBNxdSXOA7Bqg==",
       "funding": [
         {
           "type": "opencollective",
@@ -2913,11 +2913,11 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
-      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -3022,9 +3022,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.13",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.13.tgz",
-      "integrity": "sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q=="
+      "version": "1.5.18",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.18.tgz",
+      "integrity": "sha512-1OfuVACu+zKlmjsNdcJuVQuVE61sZOLbNM4JAQ1Rvh6EOj0/EUKhMJjRH73InPlXSh8HIJk1cVZ8pyOV/FMdUQ=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -5107,12 +5107,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/mocha/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
-    },
     "node_modules/mocha/node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -5159,9 +5153,9 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nanoid": {
       "version": "2.1.11",
@@ -5560,9 +5554,9 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
+      "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -6266,9 +6260,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
       "dev": true,
       "peer": true,
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "cld3-asm": "^3.1.1",
         "clone": "^2.1.2",
         "debug": "^4.3.7",
-        "isbn3": "^1.1.52",
+        "isbn3": "^1.2.0",
         "iso9_1995": "^0.0.2",
         "langs": "^2.0.0",
         "node-fetch": "^2.7.0",
@@ -26,7 +26,7 @@
       },
       "devDependencies": {
         "@babel/cli": "^7.25.6",
-        "@babel/core": "^7.24.7",
+        "@babel/core": "^7.25.2",
         "@babel/preset-env": "^7.25.4",
         "@natlibfi/eslint-config-melinda-backend": "^3.0.5",
         "@natlibfi/fixugen": "^2.0.9",
@@ -36,10 +36,10 @@
         "chai": "^4.5.0",
         "chai-as-promised": "^7.1.2",
         "cross-env": "^7.0.3",
-        "eslint": "^8.57.0",
-        "fetch-mock": "^11.1.3",
-        "mocha": "^10.4.0",
-        "nyc": "^17.0.0"
+        "eslint": "^8.57.1",
+        "fetch-mock": "^11.1.4",
+        "mocha": "^10.7.3",
+        "nyc": "^17.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -1804,9 +1804,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.0.tgz",
-      "integrity": "sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.1.tgz",
+      "integrity": "sha512-m4DVN9ZqskZoLU5GlWZadwDnYo3vAEydiUayB9widCl9ffWx2IvPnp6n3on5rJmziJSw9Bv+Z3ChDVdMwXCY8Q==",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -1903,22 +1903,22 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
-      "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.14",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
-      "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
       "deprecated": "Use @eslint/config-array instead",
       "dev": true,
       "dependencies": {
-        "@humanwhocodes/object-schema": "^2.0.2",
+        "@humanwhocodes/object-schema": "^2.0.3",
         "debug": "^4.3.1",
         "minimatch": "^3.0.5"
       },
@@ -2670,9 +2670,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001660",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001660.tgz",
-      "integrity": "sha512-GacvNTTuATm26qC74pt+ad1fW15mlQ/zuTzzY1ZoIzECTP8HURDfF43kNxPgf7H1jmelCBQTTbBNxdSXOA7Bqg==",
+      "version": "1.0.30001663",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001663.tgz",
+      "integrity": "sha512-o9C3X27GLKbLeTYZ6HBOLU1tsAcBZsLis28wrVzddShCS16RujjHp9GDHKZqrB3meE0YjhawvMFsGb/igqiPzA==",
       "funding": [
         {
           "type": "opencollective",
@@ -3022,9 +3022,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.19",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.19.tgz",
-      "integrity": "sha512-kpLJJi3zxTR1U828P+LIUDZ5ohixyo68/IcYOHLqnbTPr/wdgn4i1ECvmALN9E16JPA6cvCG5UG79gVwVdEK5w=="
+      "version": "1.5.27",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.27.tgz",
+      "integrity": "sha512-o37j1vZqCoEgBuWWXLHQgTN/KDKe7zwpiY5CPeq2RvUqOyJw9xnrULzZAEVQ5p4h+zjMk7hgtOoPdnLxr7m/jw=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -3068,16 +3068,16 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
-      "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
         "@eslint/eslintrc": "^2.1.4",
-        "@eslint/js": "8.57.0",
-        "@humanwhocodes/config-array": "^0.11.14",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "@ungap/structured-clone": "^1.2.0",
@@ -3744,9 +3744,9 @@
       }
     },
     "node_modules/fetch-mock": {
-      "version": "11.1.3",
-      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-11.1.3.tgz",
-      "integrity": "sha512-ATh0dWgnVrUHiiXuvQm1Ry+ThWfSv1QQgqJTCtybrNxyUrFiSOaDKsNG29eyysp1SHeNP6Q+dH50+8VifN51Ig==",
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-11.1.4.tgz",
+      "integrity": "sha512-Enndh1ApARgYDPfWFgfzLeSgdQVasMj6qDWDArya6quj3Z83AVGsl1YrVe8OxWVWsN7a+56RQRoGNmo9HdldAg==",
       "dev": true,
       "dependencies": {
         "@types/glob-to-regexp": "^0.4.4",
@@ -3844,16 +3844,31 @@
       "dev": true
     },
     "node_modules/foreground-child": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
-      "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
       "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.0",
-        "signal-exit": "^3.0.2"
+        "signal-exit": "^4.0.1"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/fromentries": {
@@ -4493,9 +4508,9 @@
       }
     },
     "node_modules/isbn3": {
-      "version": "1.1.52",
-      "resolved": "https://registry.npmjs.org/isbn3/-/isbn3-1.1.52.tgz",
-      "integrity": "sha512-eXkto3ehvZcGB5mMpyrhVMM8lo6I4NhkCziOxyYNmVVOg4dveEQ5L5J6AxdZkD4iienVfELukrjeLdLOdyUkyg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/isbn3/-/isbn3-1.2.0.tgz",
+      "integrity": "sha512-ackTSv/bE4MxrMIoqwl9FihRFHKdoM+E3hxYeRoYozoaCFuhxjtlS/27kkdUD75bG+CwO6Z1pYxxVYY+66rqAA==",
       "bin": {
         "isbn": "bin/isbn",
         "isbn-audit": "bin/isbn-audit",
@@ -5214,9 +5229,9 @@
       }
     },
     "node_modules/nyc": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-17.0.0.tgz",
-      "integrity": "sha512-ISp44nqNCaPugLLGGfknzQwSwt10SSS5IMoPR7GLoMAyS18Iw5js8U7ga2VF9lYuMZ42gOHr3UddZw4WZltxKg==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-17.1.0.tgz",
+      "integrity": "sha512-U42vQ4czpKa0QdI1hu950XuNhYqgoM+ZF1HT+VuUHL9hPfDPVvNQyltmMqdE9bUHMVa+8yNbc3QKTj8zQhlVxQ==",
       "dev": true,
       "dependencies": {
         "@istanbuljs/load-nyc-config": "^1.0.0",
@@ -5226,7 +5241,7 @@
         "decamelize": "^1.2.0",
         "find-cache-dir": "^3.2.0",
         "find-up": "^4.1.0",
-        "foreground-child": "^2.0.0",
+        "foreground-child": "^3.3.0",
         "get-package-type": "^0.1.0",
         "glob": "^7.1.6",
         "istanbul-lib-coverage": "^3.0.0",
@@ -5717,9 +5732,9 @@
       "dev": true
     },
     "node_modules/regenerate-unicode-properties": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.1.1.tgz",
-      "integrity": "sha512-X007RyZLsCJVVrjgEFVpLUTZwyOZk3oiL75ZcuYjlIWd6rNJtOjkBwQc5AsRrpbKVkxN6sklw/k/9m2jJYOf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.0.tgz",
+      "integrity": "sha512-DqHn3DwbmmPVzeKj9woBadqmXxLvQoQIwu7nopMc72ztvxVmVk2SBhSnx67zuye5TP+lJsb/TBQsjLKhnDf3MA==",
       "dev": true,
       "dependencies": {
         "regenerate": "^1.4.2"
@@ -6030,6 +6045,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/spawn-wrap/node_modules/foreground-child": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+      "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/spawn-wrap/node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -6274,9 +6302,9 @@
       }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
-      "integrity": "sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
+      "integrity": "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -6296,9 +6324,9 @@
       }
     },
     "node_modules/unicode-match-property-value-ecmascript": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.1.0.tgz",
-      "integrity": "sha512-qxkjQt6qjg/mYscYMC0XKRn3Rh0wFPlfxB0xkt9CfyTvpX1Ra0+rAmdX2QyAobptSEvuy4RtpPRui6XkV+8wjA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.0.tgz",
+      "integrity": "sha512-4IehN3V/+kkr5YeSSDDQG8QLqO26XpL2XP3GQtqwlT/QYSECAwFztxVHjlbh0+gjJ3XmNLS0zDsbgs9jWKExLg==",
       "dev": true,
       "engines": {
         "node": ">=4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3022,9 +3022,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.18",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.18.tgz",
-      "integrity": "sha512-1OfuVACu+zKlmjsNdcJuVQuVE61sZOLbNM4JAQ1Rvh6EOj0/EUKhMJjRH73InPlXSh8HIJk1cVZ8pyOV/FMdUQ=="
+      "version": "1.5.19",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.19.tgz",
+      "integrity": "sha512-kpLJJi3zxTR1U828P+LIUDZ5ohixyo68/IcYOHLqnbTPr/wdgn4i1ECvmALN9E16JPA6cvCG5UG79gVwVdEK5w=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "clone": "^2.1.2",
     "debug": "^4.3.7",
     "iso9_1995": "^0.0.2",
-    "isbn3": "^1.1.52",
+    "isbn3": "^1.2.0",
     "langs": "^2.0.0",
     "node-fetch": "^2.7.0",
     "sfs4900": "^0.0.1",
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.25.6",
-    "@babel/core": "^7.24.7",
+    "@babel/core": "^7.25.2",
     "@babel/preset-env": "^7.25.4",
     "@natlibfi/eslint-config-melinda-backend": "^3.0.5",
     "@natlibfi/fixugen": "^2.0.9",
@@ -67,10 +67,10 @@
     "chai": "^4.5.0",
     "chai-as-promised": "^7.1.2",
     "cross-env": "^7.0.3",
-    "eslint": "^8.57.0",
-    "fetch-mock": "^11.1.3",
-    "mocha": "^10.4.0",
-    "nyc": "^17.0.0"
+    "eslint": "^8.57.1",
+    "fetch-mock": "^11.1.4",
+    "mocha": "^10.7.3",
+    "nyc": "^17.1.0"
   },
   "eslintConfig": {
     "extends": [

--- a/package.json
+++ b/package.json
@@ -40,10 +40,10 @@
     "@babel/register": "^7.24.6",
     "@natlibfi/issn-verify": "^1.0.4",
     "@natlibfi/marc-record": "^9.0.1",
-    "@natlibfi/marc-record-validate": "^8.0.8",
+    "@natlibfi/marc-record-validate": "^8.0.10",
     "cld3-asm": "^3.1.1",
     "clone": "^2.1.2",
-    "debug": "^4.3.4",
+    "debug": "^4.3.7",
     "iso9_1995": "^0.0.2",
     "isbn3": "^1.1.52",
     "langs": "^2.0.0",
@@ -53,15 +53,15 @@
     "xregexp": "^5.1.1"
   },
   "peerDependencies": {
-    "@natlibfi/marc-record-validate": "^8.0.7"
+    "@natlibfi/marc-record-validate": "^8.0.10"
   },
   "devDependencies": {
     "@babel/cli": "^7.25.6",
     "@babel/core": "^7.24.7",
     "@babel/preset-env": "^7.25.4",
     "@natlibfi/eslint-config-melinda-backend": "^3.0.5",
-    "@natlibfi/fixugen": "^2.0.5",
-    "@natlibfi/fixura": "^3.0.5",
+    "@natlibfi/fixugen": "^2.0.9",
+    "@natlibfi/fixura": "^3.0.8",
     "babel-plugin-istanbul": "^7.0.0",
     "babel-plugin-rewire": "^1.2.0",
     "chai": "^4.5.0",

--- a/src/cyrillux.js
+++ b/src/cyrillux.js
@@ -104,7 +104,9 @@ export default function (config = {}) {
   }
 
   function fieldCanBeTransliterated(field) {
-    // Skip certain tags ('880' is the actual skip-me beef here, but we have seen other no-nos as well)
+    // Skip certain tags ('880' is the actual skip-me beef here, but we have seen other no-nos as well).
+    // Discussion: We should probably also skip others like 05X-08X, 648, 650, 651, and 655, but this needs thinking...
+    // Also I'd like to co CYRILLIC->ISO-9 for field 300 (and others?) without 880 mappings...
     if (['336', '337', '338', '880'].includes(field.tag)) {
       return false;
     }

--- a/src/cyrillux.js
+++ b/src/cyrillux.js
@@ -122,8 +122,18 @@ export default function (config = {}) {
   }
 
 
-  function mapSubfieldToIso9(subfield) {
-    const value = subfieldShouldTransliterateToIso9(subfield) ? iso9.convertToLatin(subfield.value) : subfield.value;
+  function mapSubfieldToIso9(subfield, tag) {
+    if (!subfieldShouldTransliterateToIso9(subfield)) {
+      return {code: subfield.code, value: subfield.code}; // just clone
+    }
+    const value = iso9.convertToLatin(localHacks(subfield.value));
+
+    function localHacks(value) {
+      if (tag === '300') { // we want 'cm' not 'sm' :)
+        return value.replace(/ см($|[ .,:;])/gu, ' cm$1'); // eslint-disable-line prefer-named-capture-group
+      }
+      return value;
+    }
     return {code: subfield.code, value};
   }
 
@@ -138,14 +148,14 @@ export default function (config = {}) {
 
     // Just converts the field to ISO-9 latinitsa, does not create any field-880s, so don't bother with $6 or $9 either
     if (!config.doISO9Transliteration && !config.doSFS4900Transliteration) {
-      const subfields = field.subfields.map(sf => mapSubfieldToIso9(sf));
+      const subfields = field.subfields.map(sf => mapSubfieldToIso9(sf, field.tag));
       return {tag: field.tag, ind1: field.ind1, ind2: field.ind2, subfields};
     }
 
     const subfield6 = deriveSubfield6('880', field.subfields, occurrenceNumber);
     const subfield9 = fieldHasSubfield(field, '9', iso9Trans) ? [] : [{code: '9', value: iso9Trans}];
 
-    const subfields = field.subfields.filter(sf => sf.code !== '6').map(sf => mapSubfieldToIso9(sf));
+    const subfields = field.subfields.filter(sf => sf.code !== '6').map(sf => mapSubfieldToIso9(sf, field.tag));
 
     return {tag: field.tag, ind1: field.ind1, ind2: field.ind2, subfields: [subfield6, ...subfields, ...subfield9]};
   }

--- a/src/cyrillux.js
+++ b/src/cyrillux.js
@@ -112,15 +112,11 @@ export default function (config = {}) {
     if (!field.subfields) {
       return false;
     }
-    // MELINDA-10330: $6 should not prevent translittaration per se.
-    // Skip fields that already have a translitteration.
-    /*
-    if (field.subfields.some(sf => sf.code === '6')) {
+    // MELINDA-10330: $6 should not prevent translittaration per se, so this restriction is no longer applied!
+
+    if (field.subfields.some(sf => sf.code === '9' && sf.value.includes('<TRANS>'))) {
       return false;
     }
-    */
-
-    // NB! We should check corresponging 880 fields here!
 
     return fieldContainsCyrillicCharacters(field); // We have something to translitterate:
   }
@@ -222,7 +218,7 @@ export default function (config = {}) {
     if (!config.doSFS4900Transliteration) {
       return false;
     }
-    return !existingPairedFields.some(f => fieldHasSubfield(f, '9', 'SFS4900 <TRANS>'));
+    return !existingPairedFields.some(f => fieldHasSubfield(f, '9', sfs4900Trans));
   }
 
   function processField(originalField, record, maxCreatedOccurrenceNumber = 0) {

--- a/src/cyrillux.js
+++ b/src/cyrillux.js
@@ -122,18 +122,12 @@ export default function (config = {}) {
   }
 
 
-  function mapSubfieldToIso9(subfield, tag) {
+  function mapSubfieldToIso9(subfield) {
     if (!subfieldShouldTransliterateToIso9(subfield)) {
       return {code: subfield.code, value: subfield.code}; // just clone
     }
-    const value = iso9.convertToLatin(localHacks(subfield.value));
+    const value = iso9.convertToLatin(subfield.value);
 
-    function localHacks(value) {
-      if (tag === '300') { // we want 'cm' not 'sm' :)
-        return value.replace(/ см($|[ .,:;])/gu, ' cm$1'); // eslint-disable-line prefer-named-capture-group
-      }
-      return value;
-    }
     return {code: subfield.code, value};
   }
 
@@ -148,14 +142,14 @@ export default function (config = {}) {
 
     // Just converts the field to ISO-9 latinitsa, does not create any field-880s, so don't bother with $6 or $9 either
     if (!config.doISO9Transliteration && !config.doSFS4900Transliteration) {
-      const subfields = field.subfields.map(sf => mapSubfieldToIso9(sf, field.tag));
+      const subfields = field.subfields.map(sf => mapSubfieldToIso9(sf));
       return {tag: field.tag, ind1: field.ind1, ind2: field.ind2, subfields};
     }
 
     const subfield6 = deriveSubfield6('880', field.subfields, occurrenceNumber);
     const subfield9 = fieldHasSubfield(field, '9', iso9Trans) ? [] : [{code: '9', value: iso9Trans}];
 
-    const subfields = field.subfields.filter(sf => sf.code !== '6').map(sf => mapSubfieldToIso9(sf, field.tag));
+    const subfields = field.subfields.filter(sf => sf.code !== '6').map(sf => mapSubfieldToIso9(sf));
 
     return {tag: field.tag, ind1: field.ind1, ind2: field.ind2, subfields: [subfield6, ...subfields, ...subfield9]};
   }

--- a/src/cyrillux.js
+++ b/src/cyrillux.js
@@ -135,15 +135,17 @@ export default function (config = {}) {
 
   function mapFieldToIso9(field, occurrenceNumber) {
     // This is the original non-880 field, that will be converted from Cyrillic to ISO
+
+    // Just converts the field to ISO-9 latinitsa, does not create any field-880s, so don't bother with $6 or $9 either
+    if (!config.doISO9Transliteration && !config.doSFS4900Transliteration) {
+      const subfields = field.subfields.map(sf => mapSubfieldToIso9(sf));
+      return {tag: field.tag, ind1: field.ind1, ind2: field.ind2, subfields};
+    }
+
     const subfield6 = deriveSubfield6('880', field.subfields, occurrenceNumber);
     const subfield9 = fieldHasSubfield(field, '9', iso9Trans) ? [] : [{code: '9', value: iso9Trans}];
 
     const subfields = field.subfields.filter(sf => sf.code !== '6').map(sf => mapSubfieldToIso9(sf));
-
-    // Just converts the field to ISO-9 latinitsa, does not create any field-880s, so don't bother with $6 or $9 either
-    if (!config.doISO9Transliteration && !config.doSFS4900Transliteration) {
-      return {tag: field.tag, ind1: field.ind1, ind2: field.ind2, subfields};
-    }
 
     return {tag: field.tag, ind1: field.ind1, ind2: field.ind2, subfields: [subfield6, ...subfields, ...subfield9]};
   }

--- a/src/cyrillux.js
+++ b/src/cyrillux.js
@@ -1,13 +1,17 @@
 //import createDebugLogger from 'debug';
 import clone from 'clone';
-import {fieldToString, fieldsToString, isControlSubfieldCode} from './utils';
+import {fieldHasSubfield, fieldToString, fieldsToString, isControlSubfieldCode, nvdebug} from './utils';
 import * as iso9 from 'iso9_1995';
-import {intToOccurrenceNumberString, recordGetMaxSubfield6OccurrenceNumberAsInteger} from './subfield6Utils';
+import {fieldGetMaxSubfield6OccurrenceNumberAsInteger, fieldGetOccurrenceNumberPairs, intToOccurrenceNumberString, recordGetMaxSubfield6OccurrenceNumberAsInteger, resetSubfield6Tag} from './subfield6Utils';
 
 import XRegExp from 'xregexp';
 import * as sfs4900 from 'sfs4900';
 import {default as sortFields} from './sortFields';
 import {default as reindexSubfield6OccurenceNumbers} from './reindexSubfield6OccurenceNumbers';
+
+const iso9Trans = 'ISO9 <TRANS>';
+const cyrillicTrans = 'CYRILLIC <TRANS>';
+const sfs4900Trans = 'SFS4900 <TRANS>';
 
 export default function (config = {}) {
 
@@ -99,17 +103,28 @@ export default function (config = {}) {
     return containsCyrillicCharacters(subfield.value);
   }
 
-  function fieldShouldTransliterateToIso9(field) {
+  function fieldCanBeTransliterated(field) {
     // Skip certain tags ('880' is the actual skip-me beef here, but we have seen other no-nos as well)
     if (['336', '337', '338', '880'].includes(field.tag)) {
       return false;
     }
-    // Skip control fields and fields that already have a translitteration
-    if (!field.subfields || field.subfields.some(sf => sf.code === '6')) {
+    // Skip control fields:
+    if (!field.subfields) {
       return false;
     }
-    return fieldContainsCyrillicCharacters(field);
+    // MELINDA-10330: $6 should not prevent translittaration per se.
+    // Skip fields that already have a translitteration.
+    /*
+    if (field.subfields.some(sf => sf.code === '6')) {
+      return false;
+    }
+    */
+
+    // NB! We should check corresponging 880 fields here!
+
+    return fieldContainsCyrillicCharacters(field); // We have something to translitterate:
   }
+
 
   function mapSubfieldToIso9(subfield) {
     const value = subfieldShouldTransliterateToIso9(subfield) ? iso9.convertToLatin(subfield.value) : subfield.value;
@@ -123,50 +138,112 @@ export default function (config = {}) {
 
 
   function mapFieldToIso9(field, occurrenceNumber) {
-    const subfield6 = {code: '6', value: `880-${occurrenceNumber}`};
-    const subfield9 = {code: '9', value: 'ISO9 <TRANS>'};
+    // This is the original non-880 field, that will be converted from Cyrillic to ISO
+    const subfield6 = deriveSubfield6('880', field.subfields, occurrenceNumber);
+    const subfield9 = fieldHasSubfield(field, '9', iso9Trans) ? [] : [{code: '9', value: iso9Trans}];
 
-    const subfields = field.subfields.map(sf => mapSubfieldToIso9(sf));
+    const subfields = field.subfields.filter(sf => sf.code !== '6').map(sf => mapSubfieldToIso9(sf));
 
+    // Just converts the field to ISO-9 latinitsa, does not create any field-880s, so don't bother with $6 or $9 either
     if (!config.doISO9Transliteration && !config.doSFS4900Transliteration) {
-      // Just converts the field to ISO-9 latinitsa, does not create any field-880s, so don't bother with $6 or $9 either
       return {tag: field.tag, ind1: field.ind1, ind2: field.ind2, subfields};
     }
 
-    return {tag: field.tag, ind1: field.ind1, ind2: field.ind2, subfields: [subfield6, ...subfields, subfield9]};
+    return {tag: field.tag, ind1: field.ind1, ind2: field.ind2, subfields: [subfield6, ...subfields, ...subfield9]};
+  }
+
+  function deriveSubfield6(tag, subfields, occurrenceNumber) {
+    const initialSubfield = {code: '6', value: `${tag}-${occurrenceNumber}`};
+    if (tag === '880') { // If *tag in subfield $6* is 880, field is not 880 :D
+      return initialSubfield;
+    }
+    // Try to use existing subfield
+    const [subfield6] = subfields.filter(sf => sf.code === '6').map(sf => clone(sf));
+    if (subfield6) {
+      resetSubfield6Tag(subfield6, tag); // Should we update occurrence number?
+      return subfield6;
+    }
+
+    return initialSubfield;
   }
 
   function mapFieldToCyrillicField880(field, occurrenceNumber) {
+    nvdebug(`Derive CYR 880 from ${fieldToString(field)}`);
+    const newSubfield6 = deriveSubfield6(field.tag, field.subfields, occurrenceNumber);
+    const newSubfield9 = fieldHasSubfield(field, '9', cyrillicTrans) ? [] : [{code: '9', value: cyrillicTrans}];
     const subfields = [
-      {code: '6', value: `${field.tag}-${occurrenceNumber}`},
-      ...field.subfields.map(sf => clone(sf)),
-      {code: '9', value: 'CYRILLIC <TRANS>'}
+      newSubfield6,
+      ...field.subfields.filter(sf => sf.code !== '6').map(sf => clone(sf)),
+      ...newSubfield9
     ];
 
-    return {tag: '880', ind1: field.ind1, ind2: field.ind2, subfields};
+    const newField = {tag: '880', ind1: field.ind1, ind2: field.ind2, subfields};
+    nvdebug(`       CYR 880      ${fieldToString(newField)}`);
+    return newField;
   }
 
   function mapFieldToSfs4900Field880(field, occurrenceNumber) {
-
+    nvdebug(`Derive SFS 880 from ${fieldToString(field)}`);
+    const newSubfield6 = deriveSubfield6(field.tag, field.subfields, occurrenceNumber);
+    const newSubfield9 = fieldHasSubfield(field, '9', sfs4900Trans) ? [] : [{code: '9', value: sfs4900Trans}];
     const subfields = [
-      {code: '6', value: `${field.tag}-${occurrenceNumber}`},
-      ...field.subfields.map(sf => mapSubfieldToSfs4900(sf)),
-      {code: '9', value: 'SFS4900 <TRANS>'}
+      newSubfield6,
+      ...field.subfields.filter(sf => sf.code !== '6').map(sf => mapSubfieldToSfs4900(sf)),
+      ...newSubfield9
     ];
 
-    return {tag: '880', ind1: field.ind1, ind2: field.ind2, subfields};
+    const newField = {tag: '880', ind1: field.ind1, ind2: field.ind2, subfields};
+    nvdebug(`       SFS 880      ${fieldToString(newField)}`);
+    return newField;
+  }
+
+  function getNewOccurrenceNumber(originalField, record, maxCreatedOccurrenceNumber = 0) {
+    const occurrenceNumber = fieldGetMaxSubfield6OccurrenceNumberAsInteger(originalField);
+    // Return existing occurrence number:
+    if (occurrenceNumber > 0) {
+      return occurrenceNumber;
+    }
+    if (maxCreatedOccurrenceNumber) {
+      return maxCreatedOccurrenceNumber + 1;
+    }
+    return recordGetMaxSubfield6OccurrenceNumberAsInteger(record) + 1;
+  }
+
+  function needsIso9Transliteration(existingPairedFields) {
+    if (!config.doISO9Transliteration) {
+      return false;
+    }
+    // Actually normal field is always converted to ISO-9, and this function checks where we move original cyrillic field to 880.
+    // Thus we look for field 880$9 "CYRILLIC <TRANS>" here, and not "ISO9 <TRANS>"!
+    return !existingPairedFields.some(f => fieldHasSubfield(f, '9', cyrillicTrans));
+  }
+
+  function needsSfs4900Transliteration(existingPairedFields) {
+    if (!config.doSFS4900Transliteration) {
+      return false;
+    }
+    return !existingPairedFields.some(f => fieldHasSubfield(f, '9', 'SFS4900 <TRANS>'));
   }
 
   function processField(originalField, record, maxCreatedOccurrenceNumber = 0) {
-    if (!fieldShouldTransliterateToIso9(originalField)) {
+    if (!fieldCanBeTransliterated(originalField)) {
       return [originalField];
     }
-    const newOccurrenceNumberAsInt = maxCreatedOccurrenceNumber ? maxCreatedOccurrenceNumber + 1 : recordGetMaxSubfield6OccurrenceNumberAsInteger(record) + 1;
+
+    nvdebug(`PROCESSING: ${fieldToString(originalField)}`);
+
+    const newOccurrenceNumberAsInt = getNewOccurrenceNumber(originalField, record, maxCreatedOccurrenceNumber);
     const newOccurrenceNumberAsString = intToOccurrenceNumberString(newOccurrenceNumberAsInt);
 
+    nvdebug(`NEW OCCURRENCE NUMBER: '${newOccurrenceNumberAsString}'`);
+
+    const existingPairedFields = fieldGetOccurrenceNumberPairs(originalField, record.get('880'));
+
+    nvdebug(`NUMBER OF PAIRED 880 FIELDS: ${existingPairedFields.length}`);
+
     const newMainField = mapFieldToIso9(originalField, newOccurrenceNumberAsString); // ISO-9
-    const newCyrillicField = config.doISO9Transliteration ? mapFieldToCyrillicField880(originalField, newOccurrenceNumberAsString) : undefined; // CYRILLIC
-    const newSFS4900Field = config.doSFS4900Transliteration ? mapFieldToSfs4900Field880(originalField, newOccurrenceNumberAsString) : undefined; /// SFS-4900
+    const newCyrillicField = needsIso9Transliteration(existingPairedFields) ? mapFieldToCyrillicField880(originalField, newOccurrenceNumberAsString) : undefined; // CYRILLIC
+    const newSFS4900Field = needsSfs4900Transliteration(existingPairedFields) ? mapFieldToSfs4900Field880(originalField, newOccurrenceNumberAsString) : undefined; /// SFS-4900
 
     return [newMainField, newCyrillicField, newSFS4900Field].filter(f => f);
   }

--- a/test-fixtures/cyrillux/f01/expectedResult.json
+++ b/test-fixtures/cyrillux/f01/expectedResult.json
@@ -7,6 +7,16 @@
       { "code": "a", "value": "Modin, Ûrij Ivanovič." },
       { "code": "9", "value": "ISO9 <TRANS>"}
     ]},
+    { "tag": "300", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-02"},
+      { "code": "a", "value": "5 cm." },
+      { "code": "9", "value": "ISO9 <TRANS>"}
+    ]},
+    { "tag": "500", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-03"},
+      { "code": "a", "value": "5 sm." },
+      { "code": "9", "value": "ISO9 <TRANS>"}
+    ]},
     { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
       {"code": "6", "value": "100-01"},
       {"code": "a", "value": "Модин, Юрий Иванович."},
@@ -16,8 +26,27 @@
       {"code": "6", "value": "100-01"},
       {"code": "a", "value": "Modin, Juri Ivanovitš."},
       {"code": "9", "value": "SFS4900 <TRANS>"}
+    ]},
+    { "tag": "880", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "6", "value": "300-02" },
+      { "code": "a", "value": "5 см."},
+      { "code": "9", "value": "CYRILLIC <TRANS>"}
+    ]},
+    { "tag": "880", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "6", "value": "300-02" },
+      { "code": "a", "value": "5 sm." },
+      { "code": "9", "value": "SFS4900 <TRANS>" }
+    ]},
+    { "tag": "880", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "6", "value": "500-03" },
+      { "code": "a", "value": "5 см." },
+      { "code": "9", "value": "CYRILLIC <TRANS>" }
+    ]},
+    { "tag": "880", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "6", "value": "500-03" },
+      { "code": "a", "value": "5 sm." },
+      { "code": "9", "value": "SFS4900 <TRANS>" }
     ]}
-
   ]
 }
 

--- a/test-fixtures/cyrillux/f01/expectedResult.json
+++ b/test-fixtures/cyrillux/f01/expectedResult.json
@@ -9,7 +9,7 @@
     ]},
     { "tag": "300", "ind1": " ", "ind2": " ", "subfields": [
       { "code": "6", "value": "880-02"},
-      { "code": "a", "value": "5 cm." },
+      { "code": "a", "value": "5 sm." },
       { "code": "9", "value": "ISO9 <TRANS>"}
     ]},
     { "tag": "500", "ind1": " ", "ind2": " ", "subfields": [

--- a/test-fixtures/cyrillux/f01/record.json
+++ b/test-fixtures/cyrillux/f01/record.json
@@ -3,6 +3,12 @@
   "fields": [
     { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
         { "code": "a", "value": "Модин, Юрий Иванович." }
+    ]},
+    { "tag": "300", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "5 см." }
+    ]},
+    { "tag": "500", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "5 см." }
     ]}
   ]
 }

--- a/test-fixtures/cyrillux/f03/expectedResult.json
+++ b/test-fixtures/cyrillux/f03/expectedResult.json
@@ -9,11 +9,11 @@
       { "code": "a", "value": "Sudʹby razvedčikov." }
     ]},
     {"tag": "500", "ind1": " ", "ind2": " ", "subfields": [
-      { "code": "8", "value": "880-01"},
+      { "code": "6", "value": "880-01"},
       { "code": "a", "value": "FOO."}
     ]},
     {"tag": "880", "ind1": " ", "ind2": " ", "subfields": [
-      { "code": "8", "value": "500-01"},
+      { "code": "6", "value": "500-01"},
       { "code": "a", "value": "BAR."}
     ]}
   ]

--- a/test-fixtures/cyrillux/f03/expectedResult.json
+++ b/test-fixtures/cyrillux/f03/expectedResult.json
@@ -7,6 +7,14 @@
     ]},
     { "tag": "245", "ind1": "1", "ind2": " ", "subfields": [
       { "code": "a", "value": "Sudʹby razvedčikov." }
+    ]},
+    {"tag": "500", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "8", "value": "880-01"},
+      { "code": "a", "value": "FOO."}
+    ]},
+    {"tag": "880", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "8", "value": "500-01"},
+      { "code": "a", "value": "BAR."}
     ]}
   ]
 }

--- a/test-fixtures/cyrillux/f03/record.json
+++ b/test-fixtures/cyrillux/f03/record.json
@@ -6,6 +6,14 @@
     ]},
     {"tag": "245", "ind1": "1", "ind2": " ", "subfields": [
       { "code": "a", "value": "Судьбы разведчиков."}
+    ]},
+    {"tag": "500", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "8", "value": "880-01"},
+      { "code": "a", "value": "FOO."}
+    ]},
+    {"tag": "880", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "8", "value": "500-01"},
+      { "code": "a", "value": "BAR."}
     ]}
   ]
 }

--- a/test-fixtures/cyrillux/f03/record.json
+++ b/test-fixtures/cyrillux/f03/record.json
@@ -8,11 +8,11 @@
       { "code": "a", "value": "Судьбы разведчиков."}
     ]},
     {"tag": "500", "ind1": " ", "ind2": " ", "subfields": [
-      { "code": "8", "value": "880-01"},
+      { "code": "6", "value": "880-01"},
       { "code": "a", "value": "FOO."}
     ]},
     {"tag": "880", "ind1": " ", "ind2": " ", "subfields": [
-      { "code": "8", "value": "500-01"},
+      { "code": "6", "value": "500-01"},
       { "code": "a", "value": "BAR."}
     ]}
   ]

--- a/test-fixtures/cyrillux/f06/expectedResult.json
+++ b/test-fixtures/cyrillux/f06/expectedResult.json
@@ -1,0 +1,53 @@
+{
+  "_validationOptions": {},
+  "leader": "12345cam  22123454i 4500",
+  "fields": [
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01"},
+      { "code": "a", "value": "Modin, Ûrij Ivanovič." },
+      { "code": "9", "value": "ISO9 <TRANS>"}
+    ]},
+    { "tag": "245", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-02"},
+      { "code": "a", "value": "Sudʹby razvedčikov." },
+      { "code": "9", "value": "ISO9 <TRANS>"}
+    ]},
+    { "tag": "650", "ind1": "4", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-03" },
+      { "code": "a", "value": "whatever." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      {"code": "6", "value": "100-01"},
+      {"code": "a", "value": "Модин, Юрий Иванович."},
+      {"code": "9", "value": "CYRILLIC <TRANS>"}
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      {"code": "6", "value": "100-01"},
+      {"code": "a", "value": "Modin, Juri Ivanovitš."},
+      {"code": "9", "value": "SFS4900 <TRANS>"}
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "100-01" },
+      { "code": "a", "value": "whatever100." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      {"code": "6", "value": "245-02"},
+      {"code": "a", "value": "Судьбы разведчиков."},
+      {"code": "9", "value": "CYRILLIC <TRANS>"}
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      {"code": "6", "value": "245-02"},
+      {"code": "a", "value": "Sudby razvedtšikov."},
+      {"code": "9", "value": "SFS4900 <TRANS>"}
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "245-02" },
+      { "code": "a", "value": "whatever245." }
+    ]},
+    { "tag": "880", "ind1": "4", "ind2": " ", "subfields": [
+      { "code": "6", "value": "650-03" },
+      { "code": "a", "value": "whatever650." }
+    ]}
+  ]
+}
+

--- a/test-fixtures/cyrillux/f06/metadata.json
+++ b/test-fixtures/cyrillux/f06/metadata.json
@@ -1,0 +1,10 @@
+{
+  "description": "Fix: fields 100  and 245 require translitteration, even if they already have unnamed 880 pair",
+  "comment": "Tests incrementation of occurrence numbers and usage of config",
+  "only": false,
+  "fix": true,
+  "config": {
+    "doISO9Transliteration": true,
+    "doSFS4900Transliteration": true
+  }
+}

--- a/test-fixtures/cyrillux/f06/record.json
+++ b/test-fixtures/cyrillux/f06/record.json
@@ -1,0 +1,29 @@
+{
+  "leader": "12345cam  22123454i 4500",
+  "fields": [
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01" },
+      { "code": "a", "value": "Модин, Юрий Иванович." }
+    ]},
+    {"tag": "245", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-02" },
+      { "code": "a", "value": "Судьбы разведчиков."}
+    ]},
+    { "tag": "650", "ind1": "4", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-03" },
+      { "code": "a", "value": "whatever." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "100-01" },
+      { "code": "a", "value": "whatever100." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "245-02" },
+      { "code": "a", "value": "whatever245." }
+    ]},
+    { "tag": "880", "ind1": "4", "ind2": " ", "subfields": [
+      { "code": "6", "value": "650-03" },
+      { "code": "a", "value": "whatever650." }
+    ]}
+  ]
+}

--- a/test-fixtures/cyrillux/f07/expectedResult.json
+++ b/test-fixtures/cyrillux/f07/expectedResult.json
@@ -1,0 +1,40 @@
+{
+  "_validationOptions": {},
+  "leader": "12345cam  22123454i 4500",
+  "fields": [
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-01"},
+      { "code": "a", "value": "Modin, Ûrij Ivanovič." },
+      { "code": "9", "value": "ISO9 <TRANS>"}
+    ]},
+    { "tag": "245", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-02"},
+      { "code": "a", "value": "Sudʹby razvedčikov." },
+      { "code": "9", "value": "ISO9 <TRANS>"}
+    ]},
+    { "tag": "650", "ind1": "4", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-03" },
+      { "code": "a", "value": "whatever." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      {"code": "6", "value": "100-01"},
+      {"code": "a", "value": "Модин, Юрий Иванович."},
+      {"code": "9", "value": "CYRILLIC <TRANS>"}
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      {"code": "6", "value": "100-01"},
+      {"code": "a", "value": "PIDÄ ALKUPERÄINEN ARVO 1."},
+      {"code": "9", "value": "SFS4900 <TRANS>"}
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      {"code": "6", "value": "245-02"},
+      {"code": "a", "value": "Sudby razvedtšikov."},
+      {"code": "9", "value": "SFS4900 <TRANS>"}
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      {"code": "6", "value": "245-02"},
+      {"code": "a", "value": "PIDÄ ALKUPERÄINEN ARVO 2."},
+      {"code": "9", "value": "CYRILLIC <TRANS>"}
+    ]}
+  ]
+}

--- a/test-fixtures/cyrillux/f07/metadata.json
+++ b/test-fixtures/cyrillux/f07/metadata.json
@@ -1,0 +1,10 @@
+{
+  "description": "Fix: fields 100  and 245: one translation is missing and the other one exists: add missing translation, keep existin (crappy translation) ",
+  "comment": "Tests also incrementation of occurrence number.",
+  "only": false,
+  "fix": true,
+  "config": {
+    "doISO9Transliteration": true,
+    "doSFS4900Transliteration": true
+  }
+}

--- a/test-fixtures/cyrillux/f07/record.json
+++ b/test-fixtures/cyrillux/f07/record.json
@@ -1,0 +1,27 @@
+{
+  "leader": "12345cam  22123454i 4500",
+  "fields": [
+    { "tag": "100", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-04" },
+      { "code": "a", "value": "Модин, Юрий Иванович." }
+    ]},
+    {"tag": "245", "ind1": "1", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-03" },
+      { "code": "a", "value": "Судьбы разведчиков."}
+    ]},
+    { "tag": "650", "ind1": "4", "ind2": " ", "subfields": [
+      { "code": "6", "value": "880-02" },
+      { "code": "a", "value": "whatever." }
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      {"code": "6", "value": "100-04"},
+      {"code": "a", "value": "PIDÄ ALKUPERÄINEN ARVO 1."},
+      {"code": "9", "value": "SFS4900 <TRANS>"}
+    ]},
+    { "tag": "880", "ind1": "1", "ind2": " ", "subfields": [
+      {"code": "6", "value": "245-03"},
+      {"code": "a", "value": "PIDÄ ALKUPERÄINEN ARVO 2."},
+      {"code": "9", "value": "CYRILLIC <TRANS>"}
+    ]}
+  ]
+}


### PR DESCRIPTION
Fix MELINDA-10330: existing tag-880 (say 245-880) mapping does not prevent doing ISO9 (to tag) and CYRILLIC (to 880) and SFS4900 (to 880) translitterations. However, old and new terms and conditionsapply. (eg. new: if field has any $9 with substring <TRANS> don't do anything, as it would get messy with ISO9 translltteration)